### PR TITLE
fix(readme): re-host the demo videos on this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cloned.
 
 ---
 
-https://github.com/user-attachments/assets/6fd8dc3e-800f-4815-a3dd-cbd3fa57f1fa
+<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/original.mp4" controls muted></video>
 
 </td>
 <td width="50%">
@@ -60,7 +60,7 @@ https://github.com/user-attachments/assets/6fd8dc3e-800f-4815-a3dd-cbd3fa57f1fa
 
 ---
 
-https://github.com/user-attachments/assets/ad8e0ee5-bf52-42fd-9dee-cf8e6131fadd
+<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/persodub.mp4" controls muted></video>
 
 </td>
 </tr>
@@ -76,22 +76,22 @@ https://github.com/user-attachments/assets/ad8e0ee5-bf52-42fd-9dee-cf8e6131fadd
 <tr>
 <td width="25%">
 
-https://github.com/user-attachments/assets/a88d7015-aacc-4e5e-b7bf-1bbf17d8e399
+<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/videolingo.mp4" controls muted></video>
 
 </td>
 <td width="25%">
 
-https://github.com/user-attachments/assets/9007b985-9de3-47bc-9845-79a0e0325c22
+<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/krillinai.mp4" controls muted></video>
 
 </td>
 <td width="25%">
 
-https://github.com/user-attachments/assets/5858e56e-0136-4bf6-a239-69c99277023e
+<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/voicepro.mp4" controls muted></video>
 
 </td>
 <td width="25%">
 
-https://github.com/user-attachments/assets/5d8f6c09-efa7-4c4d-8fc1-74963c5ad60a
+<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/voicestudio.mp4" controls muted></video>
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cloned.
 
 ---
 
-<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/original.mp4" controls muted></video>
+https://github.com/user-attachments/assets/39589651-83fe-4673-91b4-fa078f0e523e
 
 </td>
 <td width="50%">
@@ -60,7 +60,7 @@ cloned.
 
 ---
 
-<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/persodub.mp4" controls muted></video>
+https://github.com/user-attachments/assets/09f6dbd8-70f1-487f-bf8d-2d9fa5cb6433
 
 </td>
 </tr>
@@ -76,22 +76,22 @@ cloned.
 <tr>
 <td width="25%">
 
-<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/videolingo.mp4" controls muted></video>
+https://github.com/user-attachments/assets/1045c7f6-eb6e-4df5-aee9-16cd231e5d53
 
 </td>
 <td width="25%">
 
-<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/krillinai.mp4" controls muted></video>
+https://github.com/user-attachments/assets/7cd0456a-0f0f-4be9-88d8-5ab5dece2f5a
 
 </td>
 <td width="25%">
 
-<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/voicepro.mp4" controls muted></video>
+https://github.com/user-attachments/assets/1d84b466-57b4-43ea-8760-35eae9a198d3
 
 </td>
 <td width="25%">
 
-<video src="https://github.com/stronghamjji/PersoDub/raw/main/docs/demo/voicestudio.mp4" controls muted></video>
+https://github.com/user-attachments/assets/fac60bb8-a18b-47ec-a9c8-c1a4509fa4fb
 
 </td>
 </tr>


### PR DESCRIPTION
The six comparison clips were user-attachments on the previous repository; making it private took them down, so the README's centrepiece 404'd for every visitor.

Re-uploaded here and relinked. **Each URL matched to its clip by sha256 against `docs/demo/`** — GitHub returned the uploads alphabetically, which is not the order the tables use, so a positional guess would have put a competitor's output under the PersoDub heading.

Verified anonymously (no cookies, browser UA): all six return 200 and match their local checksums.
