### PR TITLE
Dub from a video link, plus desktop auto-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,8 @@ node_modules/
 
 # ---- Agent worktrees / local tooling (never publish) ----
 .claude/
+.superpowers/
 dub.sh
+
+# ---- Internal design docs (never publish) ----
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ PersoDub contains no analytics, telemetry, or usage reporting. When a Perso key 
 configured, requests to Perso carry a header identifying the application name, version,
 and operating system family so the vendor can attribute API usage.
 
+The desktop app checks GitHub Releases once at launch to learn whether a newer
+version exists, and downloads it in the background when there is one. The request
+carries no personal data — it is the same anonymous read anyone makes opening the
+releases page. Set `PERSODUB_DISABLE_UPDATE_CHECK=1` in the kit's `mac.env` to turn
+the check off entirely; the app then makes no network requests of its own at all.
+
 ## Responsible use
 
 PersoDub clones the voices of real people. Please use it accordingly.
@@ -287,6 +293,13 @@ PersoDub clones the voices of real people. Please use it accordingly.
 - Do not use PersoDub to impersonate anyone, or to misrepresent what a person said.
 - You are responsible for holding the rights to your source material and for complying
   with the laws and regulations that apply where you are.
+
+**Dubbing from a link.** Link fetching is powered by [yt-dlp](https://github.com/yt-dlp/yt-dlp)
+(released under the [Unlicense](https://github.com/yt-dlp/yt-dlp/blob/master/LICENSE)),
+installed from PyPI on your machine at install time; PersoDub does not bundle or
+redistribute its code. The fetched video is saved locally and dubbed locally, like any
+dropped file. Only dub videos you hold the rights to — downloading content may be
+restricted by the source platform's terms of service, and that responsibility is yours.
 
 ## Known limitations
 

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.jobs import JobStore
 from app.perso_client import APP_VERSION, SIGNUP_LINK, list_dubbing_spaces
 from app.pipeline import run_dub
 from app.settings_env import read_key_status, read_value, write_keys
+from app.source_fetch import FetchError, fetch as fetch_source, probe as probe_source
 from app.translate import get_translator
 
 app = FastAPI(title="PersoDub", version=APP_VERSION)
@@ -290,7 +291,8 @@ def _ollama_unavailable_message(engine_name: str, status: str, model_tag: str) -
 
 @app.post("/api/dub/start")
 def dub_start(
-    video: UploadFile = File(...),
+    video: Optional[UploadFile] = File(None),
+    source_url: Optional[str] = Form(None),
     srt: Optional[UploadFile] = File(None),
     source_srt: Optional[UploadFile] = File(None),
     language: str = Form("English"),
@@ -314,6 +316,13 @@ def dub_start(
     job with an actionable message (no silent local substitute — the engine was
     chosen for a reason); pick Whisper explicitly for the free offline path.
     """
+    # Exactly one source. Accepting both would silently pick a winner, and the
+    # user would watch the wrong video get dubbed.
+    source_url = (source_url or "").strip() or None
+    has_upload = video is not None and bool(video.filename)
+    if has_upload == bool(source_url):
+        raise HTTPException(422, "Provide either a video file or a source_url, not both.")
+
     # Normalize like translate_engine below: without this, "Perso" (capital P)
     # skipped both the preflight and the Perso branch and silently ran the
     # free local engine -- the exact downgrade the no-fallback rule forbids.
@@ -358,8 +367,9 @@ def dub_start(
     work = os.path.join(WORKSPACE, uuid.uuid4().hex[:8])
     os.makedirs(work, exist_ok=True)
     video_path = os.path.join(work, "input.mp4")
-    with open(video_path, "wb") as f:
-        shutil.copyfileobj(video.file, f)
+    if has_upload:
+        with open(video_path, "wb") as f:
+            shutil.copyfileobj(video.file, f)
 
     srt_path = None
     if srt is not None and srt.filename:
@@ -374,12 +384,20 @@ def dub_start(
     out_path = os.path.join(work, "dubbed.mp4")
 
     jid = job_store.create()
-    # First log line names the source video -- log files are job-<id>.log, so
-    # without this there is no way to tell which video a log belongs to.
-    job_store.append_log(jid, f"🎬 {video.filename or 'video'}")
-    job_store.start(
-        jid,
-        lambda log: run_dub(
+    # The download filenames are built from this; the job record is the only
+    # place the result endpoints can read the user's choice back from.
+    job_store._update(jid, language_code=language_code)
+    # First log line names the source -- log files are job-<id>.log, so without
+    # this there is no way to tell which video a log belongs to.
+    job_store.append_log(jid, f"🎬 {source_url or video.filename or 'video'}")
+
+    def _target(log):
+        if source_url:
+            fetch_source(
+                source_url, video_path, log=log,
+                cancel_check=lambda: job_store.is_cancel_requested(jid),
+            )
+        return run_dub(
             video_path=video_path,
             srt_path=srt_path,
             source_srt_path=source_srt_path,
@@ -394,9 +412,27 @@ def dub_start(
             cancel_check=lambda: job_store.is_cancel_requested(jid),
             on_notice=lambda n: job_store.append_notice(jid, n),
             log=log,
-        ),
-    )
+        )
+
+    job_store.start(jid, _target)
     return {"job_id": jid, "status": "running"}
+
+
+class ProbeRequest(BaseModel):
+    url: str
+
+
+@app.post("/api/source/probe")
+def source_probe(body: ProbeRequest):
+    """Read a link's title/duration/thumbnail without downloading it.
+
+    Answers in seconds, which is what lets the UI show a confirm card before
+    committing the user to an hours-long dub.
+    """
+    try:
+        return probe_source(body.url)
+    except FetchError as e:
+        raise HTTPException(422, {"reason": e.reason, "message": e.message})
 
 
 class TranslateRequest(BaseModel):
@@ -418,6 +454,10 @@ def translate_api(body: TranslateRequest):
     return {"translations": out}
 
 
+def _target_code(job: dict) -> str:
+    return job.get("language_code") or "out"
+
+
 @app.get("/api/dub/result/{jid}")
 def dub_result(jid: str):
     """Return the finished dubbed file."""
@@ -429,11 +469,31 @@ def dub_result(jid: str):
     out = (j.get("result") or {}).get("out_path")
     if not out or not os.path.exists(out):
         raise HTTPException(status_code=404, detail="Result file not found")
-    return FileResponse(out, media_type="video/mp4", filename="dubbed.mp4")
+    return FileResponse(out, media_type="video/mp4",
+                        filename=f"dubbed_{_target_code(j)}.mp4")
+
+
+@app.get("/api/dub/result/{jid}/original")
+def dub_result_original(jid: str):
+    """Return the source video the job worked from.
+
+    Same file for both entry paths: an upload is copied to input.mp4 and a
+    fetched link is written to input.mp4, so this needs no special case.
+    """
+    j = job_store.get(jid)
+    if j is None:
+        raise HTTPException(status_code=404, detail=f"Unknown job: {jid}")
+    out = (j.get("result") or {}).get("out_path")
+    if not out:
+        raise HTTPException(status_code=404, detail="Result file not found")
+    original = os.path.join(os.path.dirname(out), "input.mp4")
+    if not os.path.exists(original):
+        raise HTTPException(status_code=404, detail="Original file not found")
+    return FileResponse(original, media_type="video/mp4", filename="original.mp4")
 
 
 @app.get("/api/dub/result/{jid}/srt")
-def dub_result_srt(jid: str):
+def dub_result_srt(jid: str, download: int = 0):
     """Return the translated subtitles used for the dub, as plain text (for the UI's
     subtitle viewer). run_dub()'s result dict doesn't carry the srt path, but it
     always writes/copies it into the same job workspace folder as out_path, under
@@ -454,5 +514,12 @@ def dub_result_srt(jid: str):
         candidate = os.path.join(work_dir, name)
         if os.path.exists(candidate):
             with open(candidate, encoding="utf-8-sig") as f:
-                return Response(content=f.read(), media_type="text/plain; charset=utf-8")
+                text = f.read()
+            headers = None
+            if download:
+                headers = {"Content-Disposition":
+                           f'attachment; filename="dubbed_{_target_code(j)}.srt"'}
+            return Response(content=text,
+                            media_type="text/plain; charset=utf-8",
+                            headers=headers)
     raise HTTPException(status_code=404, detail="Subtitle file not found")

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -341,6 +341,9 @@ def run_dub(
     # local engine meant paid-quality was quietly downgraded with only a log
     # line to show for it (user decision 2026-08-06: no fallback; say what is
     # wrong and how to fix it instead).
+    # Whisper auto-detects the source language; capture it so the result can
+    # surface it. Perso STT reports no language, so this stays None there.
+    detected_language = {"code": None}
     perso_cues = None
     if stt_engine == "perso":
         try:
@@ -411,7 +414,10 @@ def run_dub(
             # forcing it once made an en->ko job decode English speech as Korean
             # phonetic gibberish. Only the UI's explicit SOURCE pick
             # (source_language_code) may be given as a hint; None = auto-detect.
-            src_cues = transcribe_local(video_path, language=source_language_code, log=log)
+            src_cues = transcribe_local(
+                video_path, language=source_language_code, log=log,
+                on_language=lambda c: detected_language.__setitem__("code", c),
+            )
         except Exception as e:
             log(f"   ❌ Local STT failed ({str(e)[:120]})")
             raise
@@ -545,4 +551,5 @@ def run_dub(
         "out_path": out_path,
         "num_segments": len(segments),
         "auto_translated": auto_translated,
+        "detected_source_language": detected_language["code"],
     }

--- a/app/source_fetch.py
+++ b/app/source_fetch.py
@@ -1,0 +1,215 @@
+"""URL -> a video file on disk. Knows nothing about dubbing.
+
+yt-dlp runs as a subprocess (never imported) for one specific reason: when a
+fetch fails and we reinstall a newer yt-dlp, the very next attempt has to use
+it. An in-process import would keep the already-loaded old module alive until
+the app restarts, which is exactly the failure this module exists to recover
+from. Shelling out to a heavy tool also matches how app/stt_local.py and
+app/qwen_scoring.py already work.
+"""
+import json
+import re
+import subprocess
+import sys
+from typing import Callable, List, Optional, Tuple
+from urllib.parse import urlparse
+
+from app.jobs import JobCancelled
+
+YTDLP_BASE = [sys.executable, "-m", "yt_dlp", "--no-playlist"]
+FETCH_TIMEOUT = 1800
+
+
+class FetchError(RuntimeError):
+    """A fetch that failed for a reason we can explain to a person.
+
+    reason is the machine-readable key ("login", "network", ...); message is
+    the sentence shown in the UI; detail carries a stderr excerpt for the log.
+    """
+
+    def __init__(self, reason: str, message: str, detail: str = ""):
+        self.reason = reason
+        self.message = message
+        self.detail = detail
+        super().__init__(message)
+
+
+# Ordered: the first group whose needle appears in stderr wins. "network" is
+# first on purpose -- see test_classify_prefers_network_over_everything.
+_PATTERNS: List[Tuple[str, Tuple[str, ...], str]] = [
+    ("network", (
+        "unable to download webpage", "nodename nor servname", "getaddrinfo",
+        "temporary failure in name resolution", "network is unreachable",
+        "connection refused", "connection reset", "timed out",
+    ), "Check your internet connection."),
+    ("login", (
+        "sign in to confirm", "sign in if you", "sign in to view", "log in",
+        "requires authentication", "members-only", "private video",
+        # Instagram wraps three different causes in one sentence
+        # ("...not available, rate-limit reached or login required"). Sign-in is
+        # the actionable one of the three, so it wins.
+        "login required", "rate-limit reached", "18 years old",
+        "this video is private",
+    ), "This video needs a sign-in, so it can't be fetched."),
+    ("geo", (
+        "not available in your country", "geo restriction", "geo-restricted",
+        "blocked in your country",
+    ), "This video isn't available in your region."),
+    ("gone", (
+        "video unavailable", "video not available", "has been removed",
+        "does not exist",
+        "account associated with this video has been terminated",
+    ), "This video is private or has been deleted."),
+    ("unsupported", (
+        "unsupported url", "is not a valid url",
+    ), "This site isn't supported yet."),
+]
+_UNKNOWN = ("unknown", "Couldn't fetch the video.")
+
+
+def classify(stderr: str) -> Tuple[str, str]:
+    """Map yt-dlp's English, technical stderr onto (reason, human sentence)."""
+    low = (stderr or "").lower()
+    for reason, needles, message in _PATTERNS:
+        if any(n in low for n in needles):
+            return reason, message
+    return _UNKNOWN
+
+
+def validate_url(url: str) -> None:
+    """Accept only web addresses. Without this yt-dlp would happily take
+    file:// paths, turning a text box into a local-file reader."""
+    parsed = urlparse((url or "").strip())
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise FetchError("unsupported", "This site isn't supported yet.", url or "")
+
+
+def _run(
+    args: List[str],
+    on_line: Optional[Callable[[str], None]] = None,
+    cancel_check: Optional[Callable[[], bool]] = None,
+    timeout: int = FETCH_TIMEOUT,
+) -> Tuple[int, str, str]:
+    """Run args, streaming stdout lines to on_line. Returns (code, out, err).
+
+    The single place this module starts a process -- tests replace exactly this
+    function, which is why nothing else in the module calls subprocess.
+    """
+    proc = subprocess.Popen(
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, bufsize=1,
+    )
+    out_lines = []
+    try:
+        for line in proc.stdout:
+            out_lines.append(line)
+            if on_line:
+                on_line(line.rstrip())
+            if cancel_check and cancel_check():
+                proc.kill()
+                proc.wait(timeout=10)
+                raise JobCancelled()
+        proc.wait(timeout=timeout)
+    except JobCancelled:
+        raise
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        raise FetchError("network", "Check your internet connection.", "timed out")
+    stderr = proc.stderr.read() if proc.stderr else ""
+    return proc.returncode, "".join(out_lines), stderr
+
+
+PROBE_TIMEOUT = 60
+
+
+def probe(url: str) -> dict:
+    """Read a link's metadata without downloading a byte.
+
+    Cheap enough (seconds) to run the moment a URL is pasted, which is what
+    makes the confirm card possible.
+    """
+    validate_url(url)
+    code, out, err = _run(
+        YTDLP_BASE + ["--dump-single-json", "--skip-download", url],
+        timeout=PROBE_TIMEOUT,
+    )
+    if code != 0:
+        reason, message = classify(err)
+        raise FetchError(reason, message, err.strip()[-300:])
+    try:
+        info = json.loads(out)
+    except Exception as e:
+        raise FetchError("unknown", _UNKNOWN[1], str(e)[:200]) from e
+    duration = info.get("duration")
+    return {
+        "title": info.get("title") or "Untitled",
+        "duration_sec": int(duration) if duration else None,
+        "thumbnail_url": info.get("thumbnail"),
+        "site": info.get("extractor_key"),
+    }
+
+
+_PERCENT = re.compile(r"\[download\]\s+([\d.]+)%")
+UPGRADE_TIMEOUT = 300
+
+
+def _upgrade() -> None:
+    """Reinstall yt-dlp at the newest version, into the venv we are running in.
+
+    Separate from _run so tests can count upgrades independently of downloads.
+    Failure is swallowed by the caller: an upgrade that cannot happen must not
+    replace the download error the user actually needs to read.
+    """
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-U", "yt-dlp"],
+        capture_output=True, text=True, timeout=UPGRADE_TIMEOUT,
+    )
+
+
+def _download_once(url: str, dest: str, log, cancel_check) -> None:
+    def on_line(line: str) -> None:
+        m = _PERCENT.search(line)
+        if m and log:
+            # "0/6 ..." is deliberate: parseProgress only advances on a matching
+            # stage number, and STAGE_LABELS has no 0, so this shows the text
+            # as-is with no stage dot lit.
+            log("0/6 Fetching video… %s%%" % m.group(1).split(".")[0])
+
+    code, _out, err = _run(
+        YTDLP_BASE + [
+            "--newline", "--no-warnings",
+            "-f", "bv*+ba/b", "--merge-output-format", "mp4",
+            "-o", dest, url,
+        ],
+        on_line=on_line,
+        cancel_check=cancel_check,
+    )
+    if code != 0:
+        reason, message = classify(err)
+        raise FetchError(reason, message, err.strip()[-300:])
+
+
+def fetch(url: str, dest: str, log=None, cancel_check=None) -> None:
+    """Download url to dest. Upgrades yt-dlp and retries once on failure.
+
+    YouTube changes how it serves video every few weeks and yt-dlp ships a fix
+    within days; a copy pinned at install time goes stale and the user reads it
+    as "the app broke". One upgrade-and-retry turns most of those into a delay
+    nobody notices. Exactly one, though -- a loop would strand the user.
+    """
+    validate_url(url)
+    try:
+        _download_once(url, dest, log, cancel_check)
+        return
+    except FetchError as first:
+        if first.reason == "network":
+            # Fetching a new yt-dlp over a dead connection fails too, and costs
+            # the user another couple of minutes to learn nothing.
+            raise
+        if log:
+            log("0/6 Updating the downloader…")
+        try:
+            _upgrade()
+        except Exception:
+            raise first
+    _download_once(url, dest, log, cancel_check)

--- a/app/stt_local.py
+++ b/app/stt_local.py
@@ -31,6 +31,7 @@ def transcribe_local(
     word_timestamps: bool = False,
     timeout: int = 900,
     log: Optional[Callable[[str], None]] = None,
+    on_language: Optional[Callable[[str], None]] = None,
 ) -> List[dict]:
     """Transcribe audio_path with local Whisper. Returns a list of cues in the
     same shape the pipeline expects everywhere else: [{"start": float,
@@ -80,10 +81,13 @@ def transcribe_local(
     if not result.get("ok"):
         raise RuntimeError("local STT reported an error (%s)" % str(result.get("error"))[:300])
 
-    if not language and log:
+    if not language:
         detected = result.get("language")
         if detected:
-            log("   detected source language: %s" % detected)
+            if log:
+                log("   detected source language: %s" % detected)
+            if on_language:
+                on_language(detected)
 
     segments = result.get("segments")
     if not segments:

--- a/desktop/entitlements.mac.plist
+++ b/desktop/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <!-- Hardened-runtime entitlements for the notarized build. Electron needs
+       JIT for V8; unsigned-executable-memory covers the helper processes.
+       Nothing here grants network/file powers - those are unrestricted for
+       non-sandboxed apps anyway, and PersoDub is not App-Store-sandboxed. -->
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, shell } from "electron";
 import { join, dirname } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { parseEnvFile } from "./src/kitEnv.js";
 import { fileURLToPath } from "node:url";
 import { loadConfig, DEFAULTS } from "./src/config.js";
 import { checkKit, readKitVersion } from "./src/engineCheck.js";
@@ -11,9 +12,55 @@ import { download } from "./src/download.js";
 import { extractTarGz } from "./src/extract.js";
 import { run } from "./src/exec.js";
 import { pullOllamaModel } from "./src/ollamaPull.js";
+import { resolveUpdateMode, resolveFeed } from "./src/updater.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 let engines = null;
+let updateDownloaded = false;
+
+// Auto-update (packaged builds only -- see src/updater.js for the decision
+// rules). Checks GitHub Releases after the window is up, downloads in the
+// background, and lets the page offer "Restart to update"; nothing is ever
+// forced. electron-updater validates the new build's code signature, which is
+// why signing came first. Errors are logged and swallowed: an update check
+// must never break a working app.
+async function startUpdater(win, kitDir) {
+  // The documented off-switch (PERSODUB_DISABLE_UPDATE_CHECK=1) lives in the
+  // kit's mac.env with the user's other settings -- read it from there, since
+  // a GUI app's process.env never carries it.
+  let env = process.env;
+  try {
+    const macEnvPath = kitDir ? join(kitDir, "mac.env") : null;
+    if (macEnvPath && existsSync(macEnvPath)) {
+      env = { ...process.env, ...parseEnvFile(readFileSync(macEnvPath, "utf8")) };
+    }
+  } catch { /* unreadable mac.env: fall back to process.env */ }
+  if (resolveUpdateMode({ isPackaged: app.isPackaged, env }) !== "auto") return;
+  try {
+    const { default: electronUpdater } = await import("electron-updater");
+    const { autoUpdater } = electronUpdater;
+    const feed = resolveFeed(process.env);
+    if (feed) autoUpdater.setFeedURL(feed);
+    autoUpdater.autoDownload = true;
+    autoUpdater.on("update-downloaded", (info) => {
+      updateDownloaded = true;
+      console.log(`PERSODUB_UPDATE downloaded ${info?.version ?? ""}`);
+      win.webContents.send("shell:update-ready", { version: info?.version ?? "" });
+      // Test-only hook: lets the end-to-end update test apply the swap without
+      // a human clicking the banner. (true, false) = silent, no relaunch --
+      // the test verifies the version stamp on disk, and a relaunched app
+      // would fight the real one over the sidecar port. Never set outside tests.
+      if (process.env.PERSODUB_TEST_AUTO_RESTART === "1") {
+        if (engines) engines.stopAll();
+        autoUpdater.quitAndInstall(true, false);
+      }
+    });
+    autoUpdater.on("error", (err) => console.warn("PERSODUB_UPDATE check failed:", String(err?.message || err)));
+    await autoUpdater.checkForUpdates();
+  } catch (err) {
+    console.warn("PERSODUB_UPDATE unavailable:", String((err && err.message) || err));
+  }
+}
 
 function fakeOverrides() {
   return {
@@ -96,6 +143,7 @@ async function boot(win) {
     });
     await win.loadURL(engines.url);
     console.log(`PERSODUB_READY ${engines.url}`);
+    startUpdater(win, cfg.kitDir); // deliberately not awaited: boot never waits on the network
   } catch (err) {
     await win.loadFile(join(HERE, "screens", "error.html"), {
       query: { message: String((err && err.message) || err), logDir: String((err && err.logDir) || "") },
@@ -104,6 +152,9 @@ async function boot(win) {
 }
 
 app.whenReady().then(() => {
+  // One greppable line naming the running version -- the e2e update test (and
+  // any future bug report) reads it instead of guessing from filenames.
+  console.log(`PERSODUB_VERSION ${app.getVersion()}`);
   const win = new BrowserWindow({
     width: 1200,
     height: 800,
@@ -149,6 +200,14 @@ app.whenReady().then(() => {
   // app.quit() (not app.exit()) so will-quit still runs and stops the child
   // engines before the fresh instance starts -- exit() would orphan them.
   ipcMain.on("shell:relaunch", () => { app.relaunch(); app.quit(); });
+  ipcMain.on("shell:restart-to-update", async () => {
+    if (!updateDownloaded) return; // stray click before a download finished
+    const { default: electronUpdater } = await import("electron-updater");
+    // quitAndInstall bypasses will-quit in some paths -- stop the engines
+    // explicitly first so no uvicorn is orphaned across the swap.
+    if (engines) engines.stopAll();
+    electronUpdater.autoUpdater.quitAndInstall();
+  });
   guardedBoot();
 });
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "persodub-desktop-shell",
       "version": "0.1.0",
+      "dependencies": {
+        "electron-updater": "^6.8.9"
+      },
       "devDependencies": {
         "electron": "^37.0.0",
         "electron-builder": "^25.1.8"
@@ -1108,7 +1111,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -1880,7 +1882,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2398,6 +2399,82 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -2965,7 +3042,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -3340,7 +3416,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3418,7 +3493,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lazystream": {
@@ -3494,6 +3568,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -3501,6 +3581,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -3858,7 +3945,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -4527,7 +4613,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -4942,6 +5027,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.7",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,13 +1,14 @@
 {
   "name": "persodub-desktop-shell",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
     "test": "node --test src/*.test.mjs smoke/*.test.mjs",
-    "dist": "node scripts/collect-payload.mjs && electron-builder --mac zip --arm64 --publish never"
+    "dist": "node scripts/collect-payload.mjs && electron-builder --mac zip --arm64 --publish never",
+    "dist:dmg": "node scripts/collect-payload.mjs && electron-builder --mac dmg --arm64 --publish never"
   },
   "devDependencies": {
     "electron": "^37.0.0",
@@ -16,13 +17,46 @@
   "build": {
     "appId": "com.persodub.desktop",
     "productName": "PersoDub",
-    "directories": { "output": "dist" },
-    "files": ["main.js", "preload.cjs", "src/**", "screens/**", "fake/**", "config.json"],
-    "extraResources": [
-      { "from": "resources/payload", "to": "payload" },
-      { "from": "../LICENSE", "to": "LICENSE" },
-      { "from": "../NOTICE", "to": "NOTICE" }
+    "directories": {
+      "output": "dist"
+    },
+    "files": [
+      "main.js",
+      "preload.cjs",
+      "src/**",
+      "screens/**",
+      "fake/**",
+      "config.json"
     ],
-    "mac": { "identity": null }
+    "extraResources": [
+      {
+        "from": "resources/payload",
+        "to": "payload"
+      },
+      {
+        "from": "../LICENSE",
+        "to": "LICENSE"
+      },
+      {
+        "from": "../NOTICE",
+        "to": "NOTICE"
+      }
+    ],
+    "mac": {
+      "hardenedRuntime": true,
+      "entitlements": "entitlements.mac.plist",
+      "entitlementsInherit": "entitlements.mac.plist",
+      "notarize": true
+    },
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "stronghamjji",
+        "repo": "PersoDub"
+      }
+    ]
+  },
+  "dependencies": {
+    "electron-updater": "^6.8.9"
   }
 }

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -8,4 +8,8 @@ contextBridge.exposeInMainWorld("persodubShell", {
   // the step that silently didn't happen.
   relaunch: () => ipcRenderer.send("shell:relaunch"),
   onInstallProgress: (cb) => ipcRenderer.on("shell:install-progress", (_e, p) => cb(p)),
+  // Auto-update: main.js announces a downloaded update; the page shows the
+  // banner and the button hands control back here to apply it.
+  onUpdateReady: (cb) => ipcRenderer.on("shell:update-ready", (_e, info) => cb(info)),
+  restartToUpdate: () => ipcRenderer.send("shell:restart-to-update"),
 });

--- a/desktop/src/updater.js
+++ b/desktop/src/updater.js
@@ -1,0 +1,29 @@
+// Auto-update decision logic. Pure functions -- the Electron wiring lives in
+// main.js; everything testable without Electron lives here.
+
+/**
+ * Should this run check for updates at all?
+ *  - "auto": check, download in background, apply on restart (packaged apps).
+ *  - "off":  never touch the network. Dev / from-source runs are always off
+ *            (their "app" is a working tree, not replaceable), and the
+ *            documented PERSODUB_DISABLE_UPDATE_CHECK=1 switch turns the
+ *            packaged check off too -- the README's no-telemetry promise
+ *            needs an escape hatch that actually silences everything.
+ */
+export function resolveUpdateMode({ isPackaged, env }) {
+  if (!isPackaged) return "off";
+  if ((env.PERSODUB_DISABLE_UPDATE_CHECK || "") === "1") return "off";
+  return "auto";
+}
+
+/**
+ * Which feed to read. null = the app's bundled app-update.yml (GitHub
+ * Releases, written by electron-builder from build.publish). A
+ * PERSODUB_UPDATE_URL override points at a generic HTTP feed -- how the
+ * update flow is tested against a local server without publishing anything.
+ */
+export function resolveFeed(env) {
+  const url = env.PERSODUB_UPDATE_URL;
+  if (url) return { provider: "generic", url };
+  return null;
+}

--- a/desktop/src/updater.test.mjs
+++ b/desktop/src/updater.test.mjs
@@ -1,0 +1,37 @@
+// Decision logic for the auto-updater: when to check at all, and which feed
+// to read. Kept pure so it tests without Electron.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveUpdateMode, resolveFeed } from "./updater.js";
+
+test("packaged app with no overrides updates automatically", () => {
+  assert.equal(resolveUpdateMode({ isPackaged: true, env: {} }), "auto");
+});
+
+test("PERSODUB_DISABLE_UPDATE_CHECK=1 turns the check fully off", () => {
+  // The README promises no phoning home beyond what it discloses; this switch
+  // is the documented way back to fully-silent behaviour.
+  assert.equal(
+    resolveUpdateMode({ isPackaged: true, env: { PERSODUB_DISABLE_UPDATE_CHECK: "1" } }),
+    "off",
+  );
+});
+
+test("dev / from-source runs never update themselves", () => {
+  // npm start runs a working tree; replacing it from a feed would clobber
+  // uncommitted work. Decision 2026-08-11: packaged channel only, for now.
+  assert.equal(resolveUpdateMode({ isPackaged: false, env: {} }), "off");
+});
+
+test("default feed is the app's bundled config (null override)", () => {
+  assert.equal(resolveFeed({}), null);
+});
+
+test("PERSODUB_UPDATE_URL points the updater at a test feed", () => {
+  // End-to-end testing serves latest-mac.yml + zip from a local HTTP server,
+  // so the flow is provable without publishing anything to GitHub.
+  assert.deepEqual(resolveFeed({ PERSODUB_UPDATE_URL: "http://127.0.0.1:8099" }), {
+    provider: "generic",
+    url: "http://127.0.0.1:8099",
+  });
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 google-auth
 python-multipart
 pytest
+yt-dlp

--- a/static/index.html
+++ b/static/index.html
@@ -223,6 +223,35 @@
   .upload-file-info { margin-top: 10px; font-size: 0.82rem; color: var(--foreground); display: none; }
   .upload-file-info.shown { display: block; }
 
+  /* Source toggle: choose an uploaded file or a pasted link. */
+  .source-toggle { display: inline-flex; gap: 4px; padding: 3px; margin-bottom: 12px; background: var(--secondary); border-radius: 999px; }
+  .source-tab { border: none; background: transparent; color: var(--muted-foreground); font-size: 0.78rem; font-weight: 600; padding: 6px 14px; border-radius: 999px; cursor: pointer; }
+  .source-tab.active { background: var(--background); color: var(--foreground); box-shadow: 0 1px 2px rgba(0,0,0,0.08); }
+  .link-input { width: 100%; padding: 11px 13px; border: 1px solid var(--border); border-radius: var(--radius); font-size: 0.85rem; color: var(--foreground); background: var(--background); }
+  .link-input:focus { outline: none; border-color: var(--primary); box-shadow: var(--focus-ring); }
+  .link-card { margin-top: 12px; border: 1px solid var(--border); border-radius: var(--radius); padding: 12px; background: var(--secondary); }
+  .link-card.error { border-color: var(--destructive); }
+  .link-card .lc-row { display: flex; gap: 12px; align-items: flex-start; }
+  .link-card img { width: 120px; border-radius: var(--radius-sm); flex: none; }
+  .link-card .lc-title { font-weight: 600; font-size: 0.86rem; color: var(--foreground); margin-bottom: 3px; }
+  .link-card .lc-meta { font-size: 0.78rem; color: var(--muted-foreground); }
+  .link-card .lc-msg { font-size: 0.83rem; color: var(--foreground); margin: 0 0 4px; }
+  .link-card .lc-sub { font-size: 0.78rem; color: var(--muted-foreground); margin: 0 0 10px; }
+  .link-card .lc-loading { font-size: 0.8rem; color: var(--muted-foreground); }
+  .result-langs { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 10px 0; font-size: 0.82rem; color: var(--muted-foreground); }
+  .result-langs b { color: var(--foreground); font-weight: 600; }
+
+  /* Auto-update banner: appears only in the desktop shell, only after a new
+     version finished downloading. Quiet by design -- no modal, no countdown. */
+  .update-banner { position: fixed; left: 50%; bottom: 18px; transform: translateX(-50%);
+    display: none; align-items: center; gap: 12px; padding: 10px 16px;
+    background: var(--foreground); color: var(--background); border-radius: 999px;
+    font-size: 0.82rem; box-shadow: 0 4px 14px rgba(0,0,0,0.25); z-index: 60; }
+  .update-banner.shown { display: flex; }
+  .update-banner button { border: none; border-radius: 999px; padding: 6px 14px;
+    font-size: 0.8rem; font-weight: 600; cursor: pointer;
+    background: var(--background); color: var(--foreground); }
+
   .btn { display: inline-flex; align-items: center; justify-content: center; gap: 6px; border: none; border-radius: var(--radius-sm); padding: 8px 16px; font-size: 0.84rem; font-weight: 600; cursor: pointer; font-family: inherit; }
   .btn-primary { background: var(--primary); color: var(--primary-foreground); }
   .btn-primary:hover { box-shadow: var(--focus-ring); }
@@ -274,7 +303,10 @@
   .result-grid { display: grid; grid-template-columns: 1.2fr 1fr; gap: 16px; }
   /* Cap the player height to the window (portrait videos used to fill the
      whole viewport and push the download buttons below the fold). */
-  .video-wrap video { width: 100%; max-height: 52vh; object-fit: contain; border-radius: var(--radius); background: #111; display: block; }
+  /* Size the player to the video's own shape (portrait stays narrow, landscape
+     wide) instead of forcing full column width -- a 9:16 short inside a forced
+     16:9 box grew black side bars that read as "my video got resized". */
+  .video-wrap video { width: auto; max-width: 100%; max-height: 52vh; object-fit: contain; border-radius: var(--radius); background: #111; display: block; margin: 0 auto; }
   .video-placeholder { background: #111; border-radius: var(--radius); aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center; color: #666; }
   /* Grow with the window instead of a fixed 320px -- show every line that
      fits; only scroll when the list is genuinely taller than the screen. */
@@ -384,7 +416,12 @@
       <!-- ============ Tab 1: Upload ============ -->
       <div class="tab-panel active" id="p-upload" data-panel="upload">
         <h2>Add your video</h2>
-        <p class="panel-desc">Drop a video file to dub, then choose the basics below.</p>
+        <p class="panel-desc">Drop a video file, or paste a link, then choose the basics below.</p>
+
+        <div class="source-toggle" role="tablist">
+          <button class="source-tab active" id="tabUpload" type="button" data-source="upload">Upload file</button>
+          <button class="source-tab" id="tabLink" type="button" data-source="link">Paste link</button>
+        </div>
 
         <div class="upload-zone" id="uploadZone" tabindex="0">
           <svg class="icon icon-lg" viewBox="0 0 24 24"><path d="M12 16V4M12 4l-4.5 4.5M12 4l4.5 4.5"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg>
@@ -392,6 +429,12 @@
           <div class="upload-hint" id="uploadHint"></div>
           <div class="upload-file-info" id="uploadFileInfo"></div>
           <input type="file" id="videoInput" accept="video/*" style="display:none">
+        </div>
+
+        <div class="link-pane" id="linkPane" hidden>
+          <input class="link-input" id="linkInput" type="url" inputmode="url"
+                 placeholder="https://www.youtube.com/watch?v=…" autocomplete="off">
+          <div class="link-card" id="linkCard" hidden></div>
         </div>
 
         <div class="section-gap">
@@ -656,7 +699,7 @@
 </div>
 
 <script type="module">
-import { LANGUAGES, buildDubFormData, startDubJob, pollDubJob, cancelDubJob, resultUrl, fetchResultSrt, parseProgress, applyEngineAvailability } from "/js/dubApi.mjs";
+import { LANGUAGES, buildDubFormData, startDubJob, pollDubJob, cancelDubJob, resultUrl, fetchResultSrt, parseProgress, applyEngineAvailability, probeSource } from "/js/dubApi.mjs";
 
 const $ = (id) => document.getElementById(id);
 
@@ -720,7 +763,9 @@ for (const [selId, defCode] of [["sourceLangSelect", null], ["targetLangSelect",
 // ---------------- App state ----------------
 const state = {
   tab: "upload",
+  source: "upload",   // "upload" | "link"
   videoFile: null,
+  linkProbe: null,    // {url, title, duration_sec, thumbnail_url} once a link probes OK
   jobId: null,
   job: null,
   pollGeneration: 0, // bumped whenever we switch jobs, so a stale poll loop stops itself
@@ -1029,6 +1074,114 @@ uploadZone.addEventListener("drop", (e) => {
   if (file) setVideoFile(file);
 });
 
+// ---------------- Auto-update banner (desktop shell only) ----------------
+// The shell announces a fully-downloaded update; outside Electron (plain
+// browser, tests) persodubShell is absent and none of this runs.
+if (window.persodubShell?.onUpdateReady) {
+  window.persodubShell.onUpdateReady((info) => {
+    let el = $("updateBanner");
+    if (!el) {
+      el = document.createElement("div");
+      el.id = "updateBanner";
+      el.className = "update-banner";
+      el.innerHTML = `<span></span><button type="button">Restart to update</button>`;
+      el.querySelector("button").addEventListener("click", () => window.persodubShell.restartToUpdate());
+      document.body.appendChild(el);
+    }
+    el.querySelector("span").textContent =
+      `Version ${info.version || "update"} is ready.`;
+    el.classList.add("shown");
+  });
+}
+
+// ---------------- Link source (paste a URL) ----------------
+// Probing is cheap (seconds, no download), so it runs as soon as a URL looks
+// complete. The card is advisory -- it never blocks the rest of the form, which
+// is why this is inline rather than a modal (see the spec's confirm-card note).
+function setSource(which) {
+  state.source = which;
+  $("tabUpload").classList.toggle("active", which === "upload");
+  $("tabLink").classList.toggle("active", which === "link");
+  $("uploadZone").hidden = which !== "upload";
+  $("linkPane").hidden = which !== "link";
+  // Only one source can be armed at a time -- clear the other so the Start
+  // button never sees both (the server would reject that anyway).
+  if (which === "upload") clearLink();
+  else setVideoFile(null);
+}
+$("tabUpload").addEventListener("click", () => setSource("upload"));
+$("tabLink").addEventListener("click", () => setSource("link"));
+
+function secsToClock(sec) {
+  if (!sec) return "";
+  const h = Math.floor(sec / 3600), m = Math.floor((sec % 3600) / 60), s = sec % 60;
+  const mm = h ? String(m).padStart(2, "0") : String(m);
+  return (h ? h + ":" : "") + mm + ":" + String(s).padStart(2, "0");
+}
+
+function clearLink() {
+  state.linkProbe = null;
+  $("linkCard").hidden = true;
+  $("linkCard").classList.remove("error");
+  $("linkCard").innerHTML = "";
+}
+
+function renderLinkLoading() {
+  const card = $("linkCard");
+  card.hidden = false;
+  card.classList.remove("error");
+  card.innerHTML = `<div class="lc-loading">Reading the link…</div>`;
+}
+
+function renderLinkCard(info) {
+  const card = $("linkCard");
+  card.hidden = false;
+  card.classList.remove("error");
+  const thumb = info.thumbnail_url
+    ? `<img src="${escapeHtml(info.thumbnail_url)}" alt="">` : "";
+  card.innerHTML = `
+    <div class="lc-row">
+      ${thumb}
+      <div>
+        <div class="lc-title">${escapeHtml(info.title)}</div>
+        <div class="lc-meta">${secsToClock(info.duration_sec)}</div>
+      </div>
+    </div>`;
+}
+
+function renderLinkError(message) {
+  const card = $("linkCard");
+  card.hidden = false;
+  card.classList.add("error");
+  card.innerHTML = `
+    <p class="lc-msg">${escapeHtml(message)}</p>
+    <p class="lc-sub">You can download the video yourself and drop it in.</p>
+    <button class="btn btn-secondary" type="button" id="linkToUpload">Upload a file</button>`;
+  $("linkToUpload").addEventListener("click", () => setSource("upload"));
+}
+
+let probeTimer = null;
+let probeSeq = 0;
+$("linkInput").addEventListener("input", () => {
+  clearTimeout(probeTimer);
+  clearLink();
+  const url = $("linkInput").value.trim();
+  if (!/^https?:\/\/\S+$/.test(url)) return;
+  const mySeq = ++probeSeq;
+  renderLinkLoading();
+  probeTimer = setTimeout(async () => {
+    try {
+      const info = await probeSource(url);
+      if (mySeq !== probeSeq) return;   // a newer edit already superseded this
+      state.linkProbe = { url, ...info };
+      renderLinkCard(info);
+    } catch (e) {
+      if (mySeq !== probeSeq) return;
+      renderLinkError(e.message);
+    }
+  }, 400);
+});
+
 // ---------------- Progress rendering ----------------
 function renderProgress(progress) {
   // Developer-only detailed dots (see applyDevDetailsVisibility) -- harmless
@@ -1272,7 +1425,8 @@ updateQualityHint();
 // ---------------- Start dubbing ----------------
 function readOptions() {
   return {
-    video: state.videoFile,
+    video: state.source === "upload" ? state.videoFile : null,
+    sourceUrl: state.source === "link" && state.linkProbe ? state.linkProbe.url : null,
     sourceLang: $("sourceLangSelect").value,
     targetLang: $("targetLangSelect").value,
     sttEngine: $("sttSelect").value,
@@ -1284,7 +1438,12 @@ function readOptions() {
 
 $("startBtn").addEventListener("click", async () => {
   $("formError").textContent = "";
-  if (!state.videoFile) { $("formError").textContent = "Choose a video first."; return; }
+  if (state.source === "upload" && !state.videoFile) {
+    $("formError").textContent = "Choose a video first."; return;
+  }
+  if (state.source === "link" && !state.linkProbe) {
+    $("formError").textContent = "Paste a link that loads a video first."; return;
+  }
 
   $("startBtn").disabled = true;
   try {
@@ -1294,9 +1453,10 @@ $("startBtn").addEventListener("click", async () => {
     state.pollGeneration += 1;
     const myGeneration = state.pollGeneration;
 
+    const label = state.source === "link" ? state.linkProbe.title : state.videoFile.name;
     unlockTabs();
     switchTab("export");
-    upsertHistory({ jobId, fileName: state.videoFile.name, lastStatus: "running", metaText: "Processing…" });
+    upsertHistory({ jobId, fileName: label, lastStatus: "running", metaText: "Processing…" });
     runPollLoop(jobId, myGeneration);
   } catch (e) {
     $("formError").textContent = e.message;
@@ -1365,22 +1525,43 @@ function renderExportRunning(progress) {
   el.innerHTML = `<div class="export-empty">${escapeHtml(progress.plainLabel || progress.label)}… the finished video appears here when the dub completes.</div>`;
 }
 
+// Human name for a language code, falling back to the code itself.
+function langName(code) {
+  if (!code) return null;
+  const l = LANGUAGES.find((x) => x.code === code);
+  return l ? l.name : code.toUpperCase();
+}
+
 // ---------------- Export tab ----------------
 async function renderExport(job) {
   const el = $("exportContent");
   const url = resultUrl(job.id);
+  const target = job.language_code || "out";
   const srtText = await fetchResultSrt(job.id).catch(() => null);
   const srtRows = srtText
     ? parseSrt(srtText).map((c) => `<div class="srt-row"><span class="srt-time">${c.start}–${c.end}</span><span class="srt-text">${escapeHtml(c.text)}</span></div>`).join("")
     : '<div class="srt-empty">No subtitle file was recorded for this job.</div>';
 
+  // The four things a finished job can hand back: original + dub, and the two
+  // languages. Source is only known when local Whisper auto-detected it
+  // (app/pipeline.py) -- otherwise show a dash rather than an empty gap.
+  const sourceName = langName((job.result || {}).detected_source_language) || "—";
+  const targetName = langName(job.language_code) || "—";
+  const langLine = `
+    <div class="result-langs">
+      <span><b>Original language:</b> ${escapeHtml(sourceName)}</span>
+      <span><b>Dubbed into:</b> ${escapeHtml(targetName)}</span>
+    </div>`;
+
   el.innerHTML = `
     <div class="result-grid">
       <div class="video-wrap">
         <video controls src="${url}"></video>
+        ${langLine}
         <div class="result-actions">
-          <a class="btn btn-primary" href="${url}" download="dubbed.mp4">Download video</a>
-          ${srtText ? `<a class="btn btn-secondary" href="/api/dub/result/${job.id}/srt" download="subtitles.srt">Download subtitles (.srt)</a>` : ""}
+          <a class="btn btn-primary" href="${url}" download="dubbed_${target}.mp4">Download dubbed video</a>
+          <a class="btn btn-secondary" href="/api/dub/result/${job.id}/original" download="original.mp4">Download original</a>
+          ${srtText ? `<a class="btn btn-secondary" href="/api/dub/result/${job.id}/srt?download=1" download="dubbed_${target}.srt">Download subtitles (.srt)</a>` : ""}
         </div>
       </div>
       <div class="srt-list">${srtRows}</div>

--- a/tests/test_auto_translate.py
+++ b/tests/test_auto_translate.py
@@ -304,7 +304,7 @@ def _stub_run_dub_until_translation(monkeypatch):
     monkeypatch.setattr(pipeline, "SeparationEngine", _FakeSep)
     monkeypatch.setattr(
         pipeline, "transcribe_local",
-        lambda video, language=None, log=None: [{"start": 0.0, "end": 2.0, "text": "hi"}],
+        lambda video, language=None, log=None, on_language=None: [{"start": 0.0, "end": 2.0, "text": "hi"}],
     )
     monkeypatch.setattr(pipeline, "diarize", lambda path, cues, num_speakers=None: cues)
 

--- a/tests/test_dub_start_url.py
+++ b/tests/test_dub_start_url.py
@@ -1,0 +1,90 @@
+"""/api/dub/start with source_url instead of an upload.
+
+run_dub and source_fetch.fetch are both replaced -- no dubbing, no network.
+"""
+import time
+
+from fastapi.testclient import TestClient
+import pytest
+
+import app.main as main
+from app.main import app
+
+client = TestClient(app, base_url="http://127.0.0.1")
+
+
+@pytest.fixture(autouse=True)
+def _all_engines_available(monkeypatch):
+    monkeypatch.setattr(main, "gemma_available", lambda: True)
+    monkeypatch.setattr(main, "qwen_available", lambda: True)
+    monkeypatch.setattr(main, "gemma_status", lambda: "available")
+    monkeypatch.setattr(main, "qwen_status", lambda: "available")
+    monkeypatch.setattr(main, "gemini_available", lambda: True)
+    monkeypatch.setattr(main, "perso_available", lambda: True)
+
+
+def _wait_done(jid, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        status = client.get(f"/api/dub/jobs/{jid}").json()["status"]
+        if status in ("done", "error", "cancelled"):
+            return status
+        time.sleep(0.02)
+    raise AssertionError("job never finished")
+
+
+def test_rejects_neither_video_nor_url():
+    r = client.post("/api/dub/start", data={"language_code": "en"})
+    assert r.status_code == 422
+    assert "video" in str(r.json()).lower() or "source_url" in str(r.json()).lower()
+
+
+def test_rejects_both_video_and_url():
+    r = client.post(
+        "/api/dub/start",
+        data={"language_code": "en", "source_url": "https://youtu.be/abc"},
+        files={"video": ("v.mp4", b"FAKE", "video/mp4")},
+    )
+    assert r.status_code == 422
+
+
+def test_url_job_fetches_before_dubbing(monkeypatch):
+    order = []
+
+    def fake_fetch(url, dest, log=None, cancel_check=None):
+        order.append("fetch")
+        with open(dest, "wb") as f:
+            f.write(b"FAKEMP4")
+
+    def fake_run_dub(**kw):
+        order.append("dub")
+        with open(kw["out_path"], "wb") as f:
+            f.write(b"FAKEDUB")
+        return {"job_id": "x", "out_path": kw["out_path"], "num_segments": 1,
+                "auto_translated": False}
+
+    monkeypatch.setattr(main, "fetch_source", fake_fetch)
+    monkeypatch.setattr(main, "run_dub", fake_run_dub)
+
+    r = client.post("/api/dub/start",
+                    data={"language_code": "en", "source_url": "https://youtu.be/abc"})
+    assert r.status_code == 200
+    _wait_done(r.json()["job_id"])
+    assert order == ["fetch", "dub"]
+
+
+def test_fetch_failure_fails_the_job_with_the_human_message(monkeypatch):
+    from app.source_fetch import FetchError
+
+    def boom(url, dest, log=None, cancel_check=None):
+        raise FetchError("geo", "This video isn't available in your region.")
+
+    monkeypatch.setattr(main, "fetch_source", boom)
+    monkeypatch.setattr(main, "run_dub", lambda **kw: pytest.fail("must not dub"))
+
+    r = client.post("/api/dub/start",
+                    data={"language_code": "en", "source_url": "https://youtu.be/abc"})
+    jid = r.json()["job_id"]
+    assert _wait_done(jid) == "error"
+    job = client.get(f"/api/dub/jobs/{jid}").json()
+    assert "region" in str(job).lower()

--- a/tests/test_result_downloads.py
+++ b/tests/test_result_downloads.py
@@ -1,0 +1,79 @@
+"""Result downloads: original.mp4 / dubbed_<lang>.mp4 / dubbed_<lang>.srt."""
+import os
+import time
+
+from fastapi.testclient import TestClient
+import pytest
+
+import app.main as main
+from app.main import app
+
+client = TestClient(app, base_url="http://127.0.0.1")
+
+
+@pytest.fixture(autouse=True)
+def _all_engines_available(monkeypatch):
+    for name in ("gemma_available", "qwen_available", "gemini_available", "perso_available"):
+        monkeypatch.setattr(main, name, lambda: True)
+    monkeypatch.setattr(main, "gemma_status", lambda: "available")
+    monkeypatch.setattr(main, "qwen_status", lambda: "available")
+
+
+def _finished_job(monkeypatch, target="en"):
+    """Start a real upload job whose pipeline is faked, and wait for it."""
+    def fake_run_dub(**kw):
+        work = os.path.dirname(kw["out_path"])
+        with open(kw["out_path"], "wb") as f:
+            f.write(b"FAKEDUB")
+        with open(os.path.join(work, "translated.srt"), "w", encoding="utf-8") as f:
+            f.write("1\n00:00:00,000 --> 00:00:01,000\nhello\n")
+        return {"job_id": "x", "out_path": kw["out_path"], "num_segments": 1,
+                "auto_translated": True}
+
+    monkeypatch.setattr(main, "run_dub", fake_run_dub)
+    r = client.post("/api/dub/start",
+                    data={"language_code": target},
+                    files={"video": ("v.mp4", b"FAKEMP4", "video/mp4")})
+    jid = r.json()["job_id"]
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if client.get(f"/api/dub/jobs/{jid}").json()["status"] == "done":
+            return jid
+        time.sleep(0.02)
+    raise AssertionError("job never finished")
+
+
+def test_dub_download_is_named_for_the_target_language(monkeypatch):
+    jid = _finished_job(monkeypatch, target="ko")
+    r = client.get(f"/api/dub/result/{jid}")
+    assert r.status_code == 200
+    assert 'filename="dubbed_ko.mp4"' in r.headers["content-disposition"]
+
+
+def test_original_is_downloadable(monkeypatch):
+    jid = _finished_job(monkeypatch)
+    r = client.get(f"/api/dub/result/{jid}/original")
+    assert r.status_code == 200
+    assert r.content == b"FAKEMP4"
+    assert 'filename="original.mp4"' in r.headers["content-disposition"]
+
+
+def test_original_404s_when_the_job_is_unknown():
+    assert client.get("/api/dub/result/nope/original").status_code == 404
+
+
+def test_srt_download_has_a_filename(monkeypatch):
+    jid = _finished_job(monkeypatch, target="ja")
+    r = client.get(f"/api/dub/result/{jid}/srt?download=1")
+    assert r.status_code == 200
+    assert 'filename="dubbed_ja.srt"' in r.headers["content-disposition"]
+
+
+def test_srt_viewer_response_is_unchanged(monkeypatch):
+    # The in-app subtitle viewer fetches this without ?download -- it must keep
+    # returning plain text with no attachment header.
+    jid = _finished_job(monkeypatch)
+    r = client.get(f"/api/dub/result/{jid}/srt")
+    assert r.status_code == 200
+    assert "content-disposition" not in {k.lower() for k in r.headers}
+    assert "hello" in r.text

--- a/tests/test_source_fetch.py
+++ b/tests/test_source_fetch.py
@@ -1,0 +1,195 @@
+"""app/source_fetch.py: URL guard and yt-dlp error classification.
+
+Nothing here touches the network. source_fetch._run is the only place that
+starts a process, and every test that needs a yt-dlp result replaces it.
+"""
+import json
+
+import pytest
+
+from app import source_fetch
+
+
+def test_rejects_non_http_urls():
+    for bad in ("file:///etc/passwd", "ftp://host/v.mp4", "/Users/me/v.mp4", ""):
+        with pytest.raises(source_fetch.FetchError) as e:
+            source_fetch.validate_url(bad)
+        assert e.value.reason == "unsupported"
+
+
+def test_accepts_http_and_https():
+    source_fetch.validate_url("https://www.youtube.com/watch?v=abc")
+    source_fetch.validate_url("http://example.com/v.mp4")
+
+
+@pytest.mark.parametrize("stderr,reason", [
+    # YouTube
+    ("ERROR: unable to download webpage: <urlopen error [Errno 8] nodename nor servname provided>", "network"),
+    ("ERROR: [youtube] abc: Sign in to confirm your age", "login"),
+    ("ERROR: [youtube] abc: This video is not available in your country", "geo"),
+    ("ERROR: [youtube] abc: Private video. Sign in if you've been granted access", "login"),
+    ("ERROR: [youtube] abc: Video unavailable. This video has been removed", "gone"),
+    # Instagram Reels -- the site that refuses most often, so its wording matters
+    ("ERROR: [Instagram] abc: Requested content is not available, rate-limit reached or login required", "login"),
+    ("ERROR: [Instagram] abc: You need to log in to access this content", "login"),
+    ("ERROR: [Instagram] abc: Restricted Video: You must be 18 years old or over to see this video", "login"),
+    # TikTok
+    ("ERROR: [TikTok] abc: Video not available", "gone"),
+    ("ERROR: [TikTok] abc: This video is private", "login"),
+    # Neither, and nothing
+    ("ERROR: Unsupported URL: https://example.com/page", "unsupported"),
+    ("ERROR: something nobody has seen before", "unknown"),
+])
+def test_classify_maps_stderr_to_a_reason(stderr, reason):
+    got_reason, message = source_fetch.classify(stderr)
+    assert got_reason == reason
+    assert message and message[0].isupper() and message.endswith(".")
+
+
+def test_classify_prefers_network_over_everything():
+    # A dead connection can produce stderr that also mentions sign-in. Retrying
+    # after an upgrade is pointless when the network is the problem, so the
+    # network verdict has to win or fetch() will waste two minutes upgrading.
+    stderr = "ERROR: unable to download webpage. Sign in to confirm your age"
+    assert source_fetch.classify(stderr)[0] == "network"
+
+
+# ---------------------------------------------------------------- probe
+
+
+def _fake_run(code=0, stdout="", stderr=""):
+    """Build a stand-in for source_fetch._run that records how it was called."""
+    calls = []
+
+    def run(args, on_line=None, cancel_check=None, timeout=None):
+        calls.append(args)
+        if on_line:
+            for line in stdout.splitlines():
+                on_line(line)
+        return code, stdout, stderr
+
+    run.calls = calls
+    return run
+
+
+def test_probe_returns_title_duration_and_thumbnail(monkeypatch):
+    payload = json.dumps({
+        "title": "How to make sourdough bread",
+        "duration": 1392,
+        "thumbnail": "https://i.ytimg.com/vi/abc/hq.jpg",
+        "extractor_key": "Youtube",
+    })
+    run = _fake_run(stdout=payload)
+    monkeypatch.setattr(source_fetch, "_run", run)
+
+    got = source_fetch.probe("https://youtu.be/abc")
+
+    assert got["title"] == "How to make sourdough bread"
+    assert got["duration_sec"] == 1392
+    assert got["thumbnail_url"] == "https://i.ytimg.com/vi/abc/hq.jpg"
+    assert got["site"] == "Youtube"
+
+
+def test_probe_never_downloads(monkeypatch):
+    run = _fake_run(stdout=json.dumps({"title": "x"}))
+    monkeypatch.setattr(source_fetch, "_run", run)
+    source_fetch.probe("https://youtu.be/abc")
+    args = run.calls[0]
+    assert "--skip-download" in args
+    assert "--no-playlist" in args
+
+
+def test_probe_raises_classified_error(monkeypatch):
+    monkeypatch.setattr(source_fetch, "_run", _fake_run(
+        code=1, stderr="ERROR: [youtube] abc: Sign in to confirm your age"))
+    with pytest.raises(source_fetch.FetchError) as e:
+        source_fetch.probe("https://youtu.be/abc")
+    assert e.value.reason == "login"
+
+
+def test_probe_raises_when_output_is_not_json(monkeypatch):
+    monkeypatch.setattr(source_fetch, "_run", _fake_run(stdout="not json at all"))
+    with pytest.raises(source_fetch.FetchError) as e:
+        source_fetch.probe("https://youtu.be/abc")
+    assert e.value.reason == "unknown"
+
+
+# ---------------------------------------------------------------- fetch
+
+
+class _Sequence:
+    """A _run stand-in that returns a different result per call."""
+
+    def __init__(self, *results):
+        self.results = list(results)
+        self.calls = []
+
+    def __call__(self, args, on_line=None, cancel_check=None, timeout=None):
+        self.calls.append(args)
+        code, stdout, stderr = self.results.pop(0)
+        if on_line:
+            for line in stdout.splitlines():
+                on_line(line)
+        return code, stdout, stderr
+
+
+def _count_upgrades(monkeypatch):
+    box = {"n": 0}
+    monkeypatch.setattr(source_fetch, "_upgrade", lambda: box.__setitem__("n", box["n"] + 1))
+    return box
+
+
+def test_fetch_succeeds_without_upgrading(monkeypatch, tmp_path):
+    upgrades = _count_upgrades(monkeypatch)
+    monkeypatch.setattr(source_fetch, "_run", _Sequence((0, "[download] 100%", "")))
+    source_fetch.fetch("https://youtu.be/abc", str(tmp_path / "input.mp4"))
+    assert upgrades["n"] == 0
+
+
+def test_fetch_upgrades_once_then_succeeds(monkeypatch, tmp_path):
+    upgrades = _count_upgrades(monkeypatch)
+    seq = _Sequence(
+        (1, "", "ERROR: [youtube] abc: Requested format is not available"),
+        (0, "[download] 100%", ""),
+    )
+    monkeypatch.setattr(source_fetch, "_run", seq)
+    lines = []
+    source_fetch.fetch("https://youtu.be/abc", str(tmp_path / "input.mp4"), log=lines.append)
+    assert upgrades["n"] == 1
+    assert len(seq.calls) == 2
+    assert any("Updating the downloader" in x for x in lines)
+
+
+def test_fetch_upgrades_at_most_once(monkeypatch, tmp_path):
+    upgrades = _count_upgrades(monkeypatch)
+    seq = _Sequence(
+        (1, "", "ERROR: boom"),
+        (1, "", "ERROR: [youtube] abc: This video is not available in your country"),
+    )
+    monkeypatch.setattr(source_fetch, "_run", seq)
+    with pytest.raises(source_fetch.FetchError) as e:
+        source_fetch.fetch("https://youtu.be/abc", str(tmp_path / "input.mp4"))
+    assert upgrades["n"] == 1
+    assert len(seq.calls) == 2
+    assert e.value.reason == "geo"  # the SECOND attempt's reason is what the user sees
+
+
+def test_fetch_skips_the_upgrade_on_network_errors(monkeypatch, tmp_path):
+    upgrades = _count_upgrades(monkeypatch)
+    seq = _Sequence((1, "", "ERROR: unable to download webpage"))
+    monkeypatch.setattr(source_fetch, "_run", seq)
+    with pytest.raises(source_fetch.FetchError) as e:
+        source_fetch.fetch("https://youtu.be/abc", str(tmp_path / "input.mp4"))
+    assert upgrades["n"] == 0
+    assert len(seq.calls) == 1
+    assert e.value.reason == "network"
+
+
+def test_fetch_reports_percentage_as_stage_zero(monkeypatch, tmp_path):
+    monkeypatch.setattr(source_fetch, "_run", _Sequence(
+        (0, "[download]   0.0% of 40MiB\n[download]  45.3% of 40MiB\n", "")))
+    lines = []
+    source_fetch.fetch("https://youtu.be/abc", str(tmp_path / "input.mp4"), log=lines.append)
+    # "0/6 …" keeps ui/src/dubApi.mjs:232 at stage 0, so no stage dot lights up
+    # and the message is shown verbatim. See the spec's "Flow" section.
+    assert any(x.startswith("0/6 ") and "45" in x for x in lines)

--- a/tests/test_source_language.py
+++ b/tests/test_source_language.py
@@ -1,0 +1,50 @@
+"""The language Whisper detects has to reach the screen.
+
+Today it is written to the log and discarded (app/stt_local.py:86), and
+static/index.html records the resulting gap.
+"""
+import json
+
+from app import stt_local
+
+
+def _fake_worker(monkeypatch, tmp_path, payload):
+    """Make transcribe_local's subprocess produce payload, with no real venv."""
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+    def fake_run(cmd, **kw):
+        out_path = cmd[cmd.index("--output") + 1]
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        return _Result()
+
+    audio = tmp_path / "a.wav"
+    audio.write_bytes(b"RIFF")
+    py = tmp_path / "py"
+    py.write_text("#!/bin/sh\n")
+    py.chmod(0o755)
+    monkeypatch.setattr(stt_local, "STT_PYTHON", str(py))
+    monkeypatch.setattr(stt_local.subprocess, "run", fake_run)
+    return str(audio)
+
+
+def test_detected_language_is_reported(monkeypatch, tmp_path):
+    audio = _fake_worker(monkeypatch, tmp_path, {
+        "ok": True, "language": "ko",
+        "segments": [{"start": 0.0, "end": 1.0, "text": "hi"}],
+    })
+    seen = []
+    stt_local.transcribe_local(audio, on_language=seen.append)
+    assert seen == ["ko"]
+
+
+def test_no_callback_when_the_caller_pinned_a_language(monkeypatch, tmp_path):
+    audio = _fake_worker(monkeypatch, tmp_path, {
+        "ok": True, "language": "ko",
+        "segments": [{"start": 0.0, "end": 1.0, "text": "hi"}],
+    })
+    seen = []
+    stt_local.transcribe_local(audio, language="en", on_language=seen.append)
+    assert seen == []  # nothing was detected -- the caller already knew

--- a/tests/test_source_probe_api.py
+++ b/tests/test_source_probe_api.py
@@ -1,0 +1,43 @@
+"""POST /api/source/probe -- metadata for the confirm card.
+
+app.source_fetch.probe is replaced in every test; nothing here reaches YouTube.
+"""
+from fastapi.testclient import TestClient
+
+import app.main as main
+from app.main import app
+from app.source_fetch import FetchError
+
+client = TestClient(app, base_url="http://127.0.0.1")
+
+
+def test_probe_returns_metadata(monkeypatch):
+    monkeypatch.setattr(main, "probe_source", lambda url: {
+        "title": "How to make sourdough bread",
+        "duration_sec": 1392,
+        "thumbnail_url": "https://i.ytimg.com/vi/abc/hq.jpg",
+        "site": "Youtube",
+    })
+    r = client.post("/api/source/probe", json={"url": "https://youtu.be/abc"})
+    assert r.status_code == 200
+    assert r.json()["title"] == "How to make sourdough bread"
+    assert r.json()["duration_sec"] == 1392
+
+
+def test_probe_surfaces_the_reason_and_message(monkeypatch):
+    def boom(url):
+        raise FetchError("login", "This video needs a sign-in, so it can't be fetched.")
+
+    monkeypatch.setattr(main, "probe_source", boom)
+    r = client.post("/api/source/probe", json={"url": "https://youtu.be/abc"})
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert detail["reason"] == "login"
+    assert "sign-in" in detail["message"]
+
+
+def test_probe_rejects_a_non_web_url(monkeypatch):
+    # No monkeypatch of probe_source: validate_url inside it must do the work.
+    r = client.post("/api/source/probe", json={"url": "file:///etc/passwd"})
+    assert r.status_code == 422
+    assert r.json()["detail"]["reason"] == "unsupported"

--- a/ui/src/dubApi.mjs
+++ b/ui/src/dubApi.mjs
@@ -88,7 +88,9 @@ export function qualityModeToNTakes(qualityMode) {
  * @returns {FormData}
  */
 export function buildDubFormData(opts) {
-  if (!opts || !opts.video) throw new Error("A video file is required.");
+  if (!opts || (!opts.video && !opts.sourceUrl)) {
+    throw new Error("A video file or a link is required.");
+  }
   let language, language_code, sourceCode = null;
   if (opts.targetLang) {
     // New source/target pair path (the Direction dropdown was split 2026-08-04).
@@ -107,7 +109,9 @@ export function buildDubFormData(opts) {
   const nTakes = opts.nTakesOverride ?? qualityModeToNTakes(opts.qualityMode ?? "fast");
 
   const fd = new FormData();
-  fd.append("video", opts.video);
+  // Exactly one source -- the server rejects both (app/main.py:dub_start).
+  if (opts.video) fd.append("video", opts.video);
+  else fd.append("source_url", opts.sourceUrl);
   fd.append("language", language);
   fd.append("language_code", language_code);
   if (sourceCode) fd.append("source_language_code", sourceCode);
@@ -208,6 +212,27 @@ export async function fetchJob(jobId, { baseUrl = "" } = {}) {
 /** URL for GET /api/dub/result/{jobId} (cache-busted). */
 export function resultUrl(jobId, { baseUrl = "" } = {}) {
   return `${baseUrl}/api/dub/result/${jobId}?t=${Date.now()}`;
+}
+
+/**
+ * POST /api/source/probe -- read a link's title/duration/thumbnail without
+ * downloading it. On failure the thrown Error carries a `.reason` (login /
+ * geo / gone / network / unsupported / unknown) so the caller can steer the
+ * user toward the upload tab with a sentence that fits.
+ */
+export async function probeSource(url, { baseUrl = "" } = {}) {
+  const res = await fetch(`${baseUrl}/api/source/probe`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+  if (!res.ok) {
+    const detail = (await res.json().catch(() => ({}))).detail || {};
+    const err = new Error(detail.message || "Couldn't fetch the video.");
+    err.reason = detail.reason || "unknown";
+    throw err;
+  }
+  return res.json();
 }
 
 /**


### PR DESCRIPTION
Paste a video link and PersoDub fetches it, then dubs it exactly like a dropped file. Getting the file — not the dubbing — is where ordinary users give up, so the link removes that wall. It works with links from most popular video sites, and everything still runs on your own machine.

## Fetching
- `app/source_fetch.py` turns a URL into a local file, run as a subprocess so a downloader upgrade takes effect on the next attempt. On failure it upgrades once and retries; a network error skips the upgrade. Only `http`/`https` URLs are accepted.
- The fetch is **stage 0 of the existing dub job**, inheriting its progress, cancel and workspace handling. Technical fetch errors are mapped to plain sentences, each ending with a route back to the upload tab.

## API + UI
- `POST /api/source/probe` reads title/duration/thumbnail without downloading. `/api/dub/start` accepts a `source_url` (exactly one of file or URL). Results download as `original.mp4` / `dubbed_<lang>.mp4` / `dubbed_<lang>.srt`, and the Export tab shows source + target languages.
- The upload screen gains an inline "paste a link" field with a preview card; a failed probe shows the reason and a way out.

## Desktop auto-update
- The packaged app checks GitHub Releases at launch, downloads in the background, and offers a quiet "Restart to update" banner — never forced. From-source runs never self-update. `PERSODUB_DISABLE_UPDATE_CHECK=1` turns the check off, keeping the no-telemetry promise honest. Builds are now signed, hardened and notarized.

## Licensing / responsibility
Link fetching relies on an open-source downloader installed from PyPI on the user's machine, not bundled. The README documents that rights to fetched content are the user's responsibility.

## Tests
New: `test_source_fetch`, `test_source_probe_api`, `test_dub_start_url`, `test_result_downloads`, `test_source_language`, plus desktop `updater.test.mjs`. All Python and desktop suites pass; none touch the network.