### PR TITLE
Fix Windows updates failing on files other programs hold open

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -8,10 +8,9 @@
 # other's upload.
 #
 # The Windows build is unsigned. SmartScreen will warn on first run; INSTALL.md
-# tells the user what to click. electron-updater verifies a signature before
-# applying an update, so automatic updates are expected NOT to work on Windows
-# until a certificate exists -- treat a Windows release as download-and-install
-# until then.
+# tells the user what to click. Automatic updates still work on the unsigned
+# build (verified end-to-end on a real 0.2.0 -> 0.3.0 update) -- a certificate
+# is only worth getting for SmartScreen reputation, not for the updater.
 name: Release Windows installer
 
 on:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,11 +174,13 @@ To enable the cloud engines:
 | **Windows:** "Windows protected your PC" blocks the installer | Click **More info**, then **Run anyway**. See ["Windows protected your PC"](#windows-protected-your-pc). |
 | **Windows:** the app was force-quit and engines are still running | Start PersoDub again. It clears the leftovers as it launches. |
 | **Windows:** uninstalled, but the disk space is still gone | The engine kit is left behind on purpose. Delete `%LOCALAPPDATA%\PersoDub` by hand. |
+| **Windows:** during an update or reinstall, the installer says "PersoDub cannot be closed. Please close it manually and click Retry to continue." even though PersoDub isn't running, and **Retry** does nothing | Another program — a code editor, antivirus, or backup tool are common culprits — has a file inside the install folder open, so the installer can't replace it yet. Close anything that might be reading files in `%LOCALAPPDATA%\Programs\PersoDub` (or just restart Windows), then click **Retry**. You can also cancel and run the installer again afterward. |
 
 ## Updating to a new version later
 
 **macOS.** Run the **same one-line command** you installed with. It fetches the latest code, rebuilds, and replaces the app.
 
-**Windows.** Download the newer `PersoDub-Setup-<version>.exe` from the
-[Releases page](https://github.com/stronghamjji/PersoDub/releases) and run it. Updates
-are not automatic on Windows while the build is unsigned.
+**Windows.** The app checks for updates on launch and downloads them in the
+background; when one is ready it offers **Restart to update**. You can also
+update by hand anytime: download the newer `PersoDub-Setup-<version>.exe` from
+the [Releases page](https://github.com/stronghamjji/PersoDub/releases) and run it.

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import { join, dirname } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 import { parseEnvFile, KIT_ENV, migrateKitEnv } from "./src/kitEnv.js";
@@ -13,6 +13,7 @@ import { extractTarGz } from "./src/extract.js";
 import { run } from "./src/exec.js";
 import { pullOllamaModel } from "./src/ollamaPull.js";
 import { resolveUpdateMode, resolveFeed } from "./src/updater.js";
+import { findForeignLockers } from "./src/lockCheck.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 let engines = null;
@@ -226,6 +227,38 @@ app.whenReady().then(() => {
   ipcMain.on("shell:relaunch", () => { app.relaunch(); app.quit(); });
   ipcMain.on("shell:restart-to-update", async () => {
     if (!updateDownloaded) return; // stray click before a download finished
+    // Windows only: the NSIS updater replaces every file in the install dir
+    // and, when some OTHER program holds one open (an editor pinning
+    // app.asar, antivirus, backup tools), it fails AFTER the app has quit --
+    // behind a retry dialog that blames the app and can't succeed until the
+    // real culprit lets go. Ask the Restart Manager now, while there is
+    // still a window to name that program in. findForeignLockers fails open,
+    // so a broken probe can only ever skip the warning, never the update.
+    if (process.platform === "win32") {
+      const lockers = await findForeignLockers({
+        installDir: dirname(process.execPath),
+        ownExePath: process.execPath,
+      });
+      // One greppable line per check -- when a user reports the installer's
+      // file-in-use dialog anyway, this says what the pre-flight saw.
+      console.log(`PERSODUB_UPDATE lock check: ${lockers.length} foreign holder(s)${lockers.length > 0 ? " -- " + lockers.map((l) => l.exe || l.name).join(", ") : ""}`);
+      if (lockers.length > 0) {
+        const names = [...new Set(lockers.map((l) => l.name || l.exe))].join(", ");
+        const { response } = await dialog.showMessageBox(win, {
+          type: "warning",
+          title: "PersoDub update",
+          message: `Close ${names} first, then update`,
+          detail:
+            "That program is using files in PersoDub's installation folder, so the " +
+            "update would stall halfway through. Close it and click \"Restart to " +
+            "update\" again -- or choose Update anyway to try regardless.",
+          buttons: ["OK", "Update anyway"],
+          defaultId: 0,
+          cancelId: 0,
+        });
+        if (response === 0) return;
+      }
+    }
     const { default: electronUpdater } = await import("electron-updater");
     // quitAndInstall bypasses will-quit in some paths -- stop the engines
     // explicitly first so no uvicorn is orphaned across the swap.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
     "test": "node --test src/*.test.mjs smoke/*.test.mjs",
     "dist": "node scripts/collect-payload.mjs && electron-builder --mac zip --arm64 --publish never",
     "dist:dmg": "node scripts/collect-payload.mjs && electron-builder --mac dmg --arm64 --publish never",
-    "dist:win": "node scripts/collect-payload.mjs && electron-builder --win nsis --x64 --publish never"
+    "dist:win": "node scripts/collect-payload.mjs && node scripts/patch-nsis-messages.mjs && electron-builder --win nsis --x64 --publish never"
   },
   "devDependencies": {
     "electron": "^37.0.0",

--- a/desktop/scripts/patch-nsis-messages.mjs
+++ b/desktop/scripts/patch-nsis-messages.mjs
@@ -1,0 +1,55 @@
+// Rewrites one message in electron-builder's NSIS catalog before makensis
+// runs. The stock appCannotBeClosed text ("${PRODUCT_NAME} cannot be closed.
+// Please close it manually and click Retry...") is shown when the old-version
+// uninstaller cannot rename a file in the install dir -- which happens when
+// ANOTHER program (editor, antivirus, backup tool) holds the file open, not
+// because the app is still running. The wording sends users hunting for an
+// app that already quit, with no way to discover the actual fix.
+//
+// Why not override the LangString from build/installer.nsh: electron-builder
+// assembles the generated message catalog and the custom include
+// concurrently, so their order in the final script -- and therefore which
+// LangString definition wins -- is a race (observed both ways in real
+// builds). Editing the catalog itself has no ordering to lose.
+//
+// Runs as a build step (see dist:win in package.json), so a fresh npm ci
+// (CI included) is patched before every build. Idempotent.
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Exact text that lands between the quotes in messages.yml. \n (a literal
+// backslash-n in the YAML double-quoted scalar) becomes the dialog's line
+// break, matching how the stock strings are written.
+export const EN_TEXT =
+  'A file in the ${PRODUCT_NAME} installation folder is in use by another program (such as an editor, antivirus, or backup tool). \\nClose those programs and click Retry, or restart your computer and run the installer again.';
+export const KO_TEXT =
+  '다른 프로그램(편집기, 백신, 백업 도구 등)이 ${PRODUCT_NAME} 설치 폴더의 파일을 사용 중입니다. \\n해당 프로그램을 닫고 다시 시도를 누르거나, 컴퓨터를 다시 시작한 뒤 설치를 다시 실행하세요.';
+
+// Replaces the whole appCannotBeClosed block: the stock translations describe
+// the wrong cause, and a translated wrong explanation is still wrong. Every
+// language not listed here falls back to the English text (nsisLang.js does
+// that for any unspecified language).
+export function patchMessages(text) {
+  const block = /^appCannotBeClosed:\r?\n(?:[ \t]+.*\r?\n?)*/m;
+  if (!block.test(text)) {
+    throw new Error("appCannotBeClosed block not found in messages.yml -- did an electron-builder upgrade change the catalog?");
+  }
+  const replacement = `appCannotBeClosed:\n  en: "${EN_TEXT}"\n  ko: "${KO_TEXT}"\n`;
+  // Replacement via function: a plain string here would let "$" sequences in
+  // the text be interpreted as replace() patterns.
+  return text.replace(block, () => replacement);
+}
+
+const SELF = fileURLToPath(import.meta.url);
+if (process.argv[1] && fileURLToPath(new URL(`file:///${process.argv[1].replace(/\\/g, "/")}`)) === SELF) {
+  const target = join(dirname(dirname(SELF)), "node_modules", "app-builder-lib", "templates", "nsis", "messages.yml");
+  const before = readFileSync(target, "utf8");
+  const after = patchMessages(before);
+  if (after === before) {
+    console.log("nsis messages: appCannotBeClosed already patched");
+  } else {
+    writeFileSync(target, after);
+    console.log("nsis messages: appCannotBeClosed patched");
+  }
+}

--- a/desktop/src/lockCheck.js
+++ b/desktop/src/lockCheck.js
@@ -1,0 +1,133 @@
+// Windows pre-flight for "Restart to update". The NSIS updater replaces every
+// file in the install directory and, if any single rename fails, aborts with a
+// dialog blaming the app ("PersoDub cannot be closed") -- when the actual
+// culprit is some OTHER program holding a file open (seen in the field: an
+// editor pinning resources\app.asar; antivirus and backup tools do the same).
+// By the time that dialog shows, the app has already quit and can't explain
+// anything. So the check runs BEFORE quitting, via the Windows Restart Manager
+// (the official "who is holding these files" API), and names the culprit while
+// there is still a window to say it in.
+//
+// Everything here fails open: a broken probe returns "no lockers", because a
+// safety check must never be the thing that blocks an update.
+import { execFile } from "node:child_process";
+import { basename } from "node:path";
+
+// The Restart Manager lives behind a C API (rstrtmgr.dll); Node can't reach it
+// without a native module, so the probe is a PowerShell script using P/Invoke.
+// It prints a JSON array of {pid, name, exe} for every process holding any
+// file under the install dir, or [] on any failure. The script is passed via
+// -EncodedCommand, so nothing touches disk and no shell quoting applies -- the
+// only interpolated value is the install dir inside a single-quoted PowerShell
+// literal, with ' doubled per PowerShell's escape rule.
+export function lockProbeScript(installDir) {
+  const dir = String(installDir).replace(/'/g, "''");
+  return `
+$ErrorActionPreference = 'Stop'
+try {
+  Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class RmProbe {
+  [StructLayout(LayoutKind.Sequential)]
+  public struct RM_UNIQUE_PROCESS { public int dwProcessId; public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime; }
+  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+  public struct RM_PROCESS_INFO {
+    public RM_UNIQUE_PROCESS Process;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)] public string strAppName;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)] public string strServiceShortName;
+    public int ApplicationType;
+    public uint AppStatus;
+    public uint TSSessionId;
+    [MarshalAs(UnmanagedType.Bool)] public bool bRestartable;
+  }
+  [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)] public static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, string strSessionKey);
+  [DllImport("rstrtmgr.dll")] public static extern int RmEndSession(uint pSessionHandle);
+  [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)] public static extern int RmRegisterResources(uint pSessionHandle, uint nFiles, string[] rgsFilenames, uint nApplications, RM_UNIQUE_PROCESS[] rgApplications, uint nServices, string[] rgsServiceNames);
+  [DllImport("rstrtmgr.dll")] public static extern int RmGetList(uint dwSessionHandle, out uint pnProcInfoNeeded, ref uint pnProcInfo, [In, Out] RM_PROCESS_INFO[] rgAffectedApps, ref uint lpdwRebootReasons);
+}
+'@
+  $files = @(Get-ChildItem -LiteralPath '${dir}' -Recurse -File | ForEach-Object { $_.FullName })
+  if ($files.Count -eq 0) { [Console]::Out.Write('[]'); exit 0 }
+  $session = [uint32]0
+  if ([RmProbe]::RmStartSession([ref]$session, 0, [Guid]::NewGuid().ToString()) -ne 0) { [Console]::Out.Write('[]'); exit 0 }
+  try {
+    if ([RmProbe]::RmRegisterResources($session, $files.Count, $files, 0, $null, 0, $null) -ne 0) { [Console]::Out.Write('[]'); exit 0 }
+    $needed = [uint32]0; $count = [uint32]0; $reasons = [uint32]0
+    $rc = [RmProbe]::RmGetList($session, [ref]$needed, [ref]$count, $null, [ref]$reasons)
+    $result = @()
+    if ($rc -eq 234 -and $needed -gt 0) {
+      $count = $needed
+      $apps = New-Object 'RmProbe+RM_PROCESS_INFO[]' $count
+      $rc = [RmProbe]::RmGetList($session, [ref]$needed, [ref]$count, $apps, [ref]$reasons)
+      if ($rc -eq 0 -and $count -gt 0) {
+        $result = foreach ($a in $apps[0..($count - 1)]) {
+          $procId = $a.Process.dwProcessId
+          $exe = ''
+          $p = Get-Process -Id $procId -ErrorAction SilentlyContinue
+          if ($p -and $p.Path) { $exe = Split-Path -Leaf $p.Path } elseif ($p) { $exe = $p.ProcessName + '.exe' }
+          [pscustomobject]@{ pid = $procId; name = $a.strAppName; exe = $exe }
+        }
+      }
+    }
+    [Console]::Out.Write((ConvertTo-Json -InputObject @($result) -Compress))
+  } finally { [void][RmProbe]::RmEndSession($session) }
+} catch { [Console]::Out.Write('[]') }
+`;
+}
+
+// The probe's stdout may carry Add-Type noise before the JSON, and
+// PowerShell's ConvertTo-Json can hand back a bare object for one element.
+// Anything unparseable means "probe broke", which fails open to [].
+export function parseLockers(stdout) {
+  if (typeof stdout !== "string") return [];
+  const text = stdout.trim();
+  for (const candidate of [text, text.slice(text.indexOf("["))]) {
+    try {
+      const parsed = JSON.parse(candidate);
+      const list = Array.isArray(parsed) ? parsed : [parsed];
+      return list
+        .filter((e) => e && typeof e === "object")
+        .map((e) => ({ pid: Number(e.pid) || 0, name: String(e.name ?? ""), exe: String(e.exe ?? "") }));
+    } catch { /* try the next candidate */ }
+  }
+  return [];
+}
+
+// The running app holds its own app.asar open -- a lock that resolves itself
+// the moment the app quits, so only OTHER programs are worth warning about.
+// Electron runs several processes (main, renderer, gpu) from the same exe;
+// match on exe name, case-insensitively, since Windows paths aren't
+// case-sensitive.
+export function foreignLockers(lockers, ownExePath) {
+  const own = basename(String(ownExePath)).toLowerCase();
+  return lockers.filter((l) => l.exe.toLowerCase() !== own);
+}
+
+// -EncodedCommand sidesteps every quoting layer, -NoProfile keeps user
+// profiles from slowing down or breaking the probe, and windowsHide avoids
+// exactly the console-flash users already complained about at app start.
+function runPowerShell(script, timeoutMs) {
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  return new Promise((resolve, reject) => {
+    execFile(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", encoded],
+      { timeout: timeoutMs, windowsHide: true, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout) => (err ? reject(err) : resolve(stdout)),
+    );
+  });
+}
+
+export async function findForeignLockers({ installDir, ownExePath, run, timeoutMs = 15000 }) {
+  try {
+    const probe = run ?? ((script) => runPowerShell(script, timeoutMs));
+    const stdout = await probe(lockProbeScript(installDir));
+    return foreignLockers(parseLockers(stdout), ownExePath);
+  } catch (err) {
+    // Fail open -- never let the check itself block an update -- but say why,
+    // or a broken probe is indistinguishable from a clean install dir.
+    console.warn("PERSODUB_UPDATE lock check failed:", String((err && err.message) || err));
+    return [];
+  }
+}

--- a/desktop/src/lockCheck.js
+++ b/desktop/src/lockCheck.js
@@ -11,7 +11,7 @@
 // Everything here fails open: a broken probe returns "no lockers", because a
 // safety check must never be the thing that blocks an update.
 import { execFile } from "node:child_process";
-import { basename } from "node:path";
+import { win32 } from "node:path";
 
 // The Restart Manager lives behind a C API (rstrtmgr.dll); Node can't reach it
 // without a native module, so the probe is a PowerShell script using P/Invoke.
@@ -100,7 +100,10 @@ export function parseLockers(stdout) {
 // match on exe name, case-insensitively, since Windows paths aren't
 // case-sensitive.
 export function foreignLockers(lockers, ownExePath) {
-  const own = basename(String(ownExePath)).toLowerCase();
+  // win32.basename explicitly: ownExePath is always a Windows path, but the
+  // test suite also runs on Linux CI, where the platform default treats
+  // backslashes as ordinary characters.
+  const own = win32.basename(String(ownExePath)).toLowerCase();
   return lockers.filter((l) => l.exe.toLowerCase() !== own);
 }
 

--- a/desktop/src/lockCheck.test.mjs
+++ b/desktop/src/lockCheck.test.mjs
@@ -1,0 +1,72 @@
+// Pre-flight check before "Restart to update" on Windows: which OTHER
+// programs hold files inside the install directory open. The NSIS updater
+// dies with a misleading "cannot be closed" dialog when e.g. an editor or
+// antivirus holds resources\app.asar -- this module names the culprit BEFORE
+// the app quits, while there is still a UI to say it in. Kept pure/injectable
+// so it tests without PowerShell or Electron.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { lockProbeScript, parseLockers, foreignLockers, findForeignLockers } from "./lockCheck.js";
+
+test("parseLockers reads the probe's JSON array", () => {
+  const out = '[{"pid":7644,"name":"Visual Studio Code","exe":"Code.exe"}]';
+  assert.deepEqual(parseLockers(out), [{ pid: 7644, name: "Visual Studio Code", exe: "Code.exe" }]);
+});
+
+test("parseLockers wraps a single-object result in an array", () => {
+  // PowerShell's ConvertTo-Json drops the array wrapper for one element, so
+  // a single locker arrives as a bare object, not a one-element array.
+  const out = '{"pid":7644,"name":"Visual Studio Code","exe":"Code.exe"}';
+  assert.deepEqual(parseLockers(out), [{ pid: 7644, name: "Visual Studio Code", exe: "Code.exe" }]);
+});
+
+test("parseLockers turns garbage or empty output into no lockers", () => {
+  // Fail open: a broken probe must never block an update.
+  assert.deepEqual(parseLockers(""), []);
+  assert.deepEqual(parseLockers("Add-Type : error CS0234 ..."), []);
+  assert.deepEqual(parseLockers(null), []);
+});
+
+test("foreignLockers drops the app's own processes, keeps others", () => {
+  // The running app holds its own app.asar open -- that lock resolves itself
+  // when the app quits, so only OTHER programs are worth warning about.
+  // Electron spawns several processes from the same exe; match by exe name,
+  // case-insensitively (Windows paths are case-preserving, not case-sensitive).
+  const lockers = [
+    { pid: 100, name: "PersoDub", exe: "PersoDub.exe" },
+    { pid: 101, name: "PersoDub", exe: "persodub.exe" },
+    { pid: 7644, name: "Visual Studio Code", exe: "Code.exe" },
+  ];
+  assert.deepEqual(
+    foreignLockers(lockers, "C:\\Users\\x\\AppData\\Local\\Programs\\PersoDub\\PersoDub.exe"),
+    [{ pid: 7644, name: "Visual Studio Code", exe: "Code.exe" }],
+  );
+});
+
+test("lockProbeScript embeds the install dir literally, apostrophes escaped", () => {
+  // The dir is spliced into a single-quoted PowerShell string; ' doubles to ''.
+  // Anything else injected verbatim would let a hostile path run as code.
+  const script = lockProbeScript("C:\\Users\\o'brien\\AppData\\Local\\Programs\\PersoDub");
+  assert.ok(script.includes("'C:\\Users\\o''brien\\AppData\\Local\\Programs\\PersoDub'"));
+});
+
+test("findForeignLockers reports foreign holders via an injected runner", async () => {
+  const run = async () => '[{"pid":7644,"name":"Visual Studio Code","exe":"Code.exe"},{"pid":1,"name":"PersoDub","exe":"PersoDub.exe"}]';
+  const got = await findForeignLockers({
+    installDir: "C:\\apps\\PersoDub",
+    ownExePath: "C:\\apps\\PersoDub\\PersoDub.exe",
+    run,
+  });
+  assert.deepEqual(got, [{ pid: 7644, name: "Visual Studio Code", exe: "Code.exe" }]);
+});
+
+test("findForeignLockers fails open when the probe blows up", async () => {
+  // An update must never be blocked by the safety check itself.
+  const run = async () => { throw new Error("powershell missing"); };
+  const got = await findForeignLockers({
+    installDir: "C:\\apps\\PersoDub",
+    ownExePath: "C:\\apps\\PersoDub\\PersoDub.exe",
+    run,
+  });
+  assert.deepEqual(got, []);
+});

--- a/desktop/src/patchNsisMessages.test.mjs
+++ b/desktop/src/patchNsisMessages.test.mjs
@@ -1,0 +1,51 @@
+// Build-time patch for electron-builder's NSIS message catalog. The stock
+// appCannotBeClosed text ("PersoDub cannot be closed...") blames the app when
+// the real cause is another program holding a file in the install folder open.
+// Overriding the LangString from build/installer.nsh is unreliable -- the
+// custom include and the generated message catalog are assembled concurrently,
+// so which definition lands last (and wins) is a race. Rewriting messages.yml
+// itself before makensis runs has no such race. Pure text-in/text-out function
+// so it tests without touching node_modules.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { patchMessages, EN_TEXT, KO_TEXT } from "../scripts/patch-nsis-messages.mjs";
+
+const SAMPLE = `appRunning:
+  en: "\${PRODUCT_NAME} is running.\\nClick OK to close it."
+  ko: "\${PRODUCT_NAME}이(가) 실행 중입니다."
+appCannotBeClosed:
+  en: "\${PRODUCT_NAME} cannot be closed. \\nPlease close it manually and click Retry to continue."
+  ar: "old arabic text"
+  bn: "old bengali text"
+decompressionFailed:
+  en: "Failed to decompress files."
+`;
+
+test("replaces the whole appCannotBeClosed block with accurate en and ko text", () => {
+  const patched = patchMessages(SAMPLE);
+  assert.ok(patched.includes(`appCannotBeClosed:\n  en: "${EN_TEXT}"\n  ko: "${KO_TEXT}"\n`));
+  // The old translations of the wrong message go away with it -- a translated
+  // wrong explanation is still a wrong explanation.
+  assert.ok(!patched.includes("old arabic text"));
+  assert.ok(!patched.includes("old bengali text"));
+  assert.ok(!patched.includes("cannot be closed"));
+});
+
+test("leaves every other message block untouched", () => {
+  const patched = patchMessages(SAMPLE);
+  assert.ok(patched.startsWith("appRunning:\n"));
+  assert.ok(patched.includes("appRunning:\n  en: \"${PRODUCT_NAME} is running."));
+  assert.ok(patched.includes("decompressionFailed:\n  en: \"Failed to decompress files.\"\n"));
+});
+
+test("is idempotent -- patching twice equals patching once", () => {
+  const once = patchMessages(SAMPLE);
+  assert.equal(patchMessages(once), once);
+});
+
+test("throws when the block it must replace is missing", () => {
+  // A silent no-op here would ship the misleading dialog again without anyone
+  // noticing -- fail the build loudly instead (e.g. after an electron-builder
+  // upgrade renames the key).
+  assert.throws(() => patchMessages("somethingElse:\n  en: \"x\"\n"), /appCannotBeClosed/);
+});


### PR DESCRIPTION
## Problem

Updating on Windows could die mid-install behind a stock dialog reading "PersoDub cannot be closed. Please close it manually and click Retry to continue." -- even though the app had already quit. The NSIS updater replaces every file in the install directory; when another program (an editor, antivirus, or backup tool) holds one open, the old-version uninstaller aborts, the installer retries five times, and the dialog blames the wrong process, so Retry can never succeed and users have no way to discover the real fix. Reproduced on a real 0.2.0 -> 0.3.0 update with an editor holding resources\app.asar.

## Changes

- **Pre-flight check** (`desktop/src/lockCheck.js`): before restarting into the installer, ask the Windows Restart Manager which other programs hold files in the install directory and name them in a dialog, with an "Update anyway" escape hatch. Fails open -- a broken probe can only skip the warning, never block the update -- and logs one greppable line per check.
- **Installer message**: rewrite the misleading `appCannotBeClosed` text (en, ko) at build time via `scripts/patch-nsis-messages.mjs`, wired into `dist:win`. Overriding the LangString from a custom NSIS include turned out to be a race -- electron-builder assembles the message catalog and the custom include concurrently, so which definition wins varies per build -- so the catalog itself is patched instead.
- **Docs**: INSTALL.md troubleshooting entry for this dialog, and the Windows update section now says updates are automatic. Corrected the release workflow comment claiming unsigned builds cannot auto-update; a real update proved they can.

Existing installs get the clearer installer message on their first update to the next release; the pre-flight dialog protects every update after that.

## Verification

- 97 unit tests pass (`npm test`), including new coverage for probe output parsing, own-process filtering, fail-open behavior, and the message patcher (idempotence, loud failure if the catalog layout changes).
- Built the NSIS installer locally and exercised the full flow against a local update feed with a file deliberately locked: the app named the locking program before quitting, and choosing "Update anyway" showed the new installer text instead of the stock one.
