### PR TITLE
Make the latest release the single install path in the docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,30 @@ Both end in the same place — [After installing](#after-installing).
 - macOS 11 (Big Sur) or later
 - 16 GB of memory (RAM) or more (24 GB recommended — the AI models use a lot of memory while dubbing)
 - An internet connection and at least 30 GB of free disk space
-- Time: about 30 minutes to install + 30 minutes to 2 hours for the automatic engine setup on first launch
+
+### Download and install
+
+1. Go to the [latest release](https://github.com/stronghamjji/PersoDub/releases/latest).
+2. Download **`PersoDub-<version>-arm64.dmg`**.
+3. Open the downloaded file and drag **PersoDub** into your **Applications** folder.
+4. Launch **PersoDub** from Applications. The app is signed and notarized, so it opens
+   with a normal double-click — no security warnings.
+
+On a first install, a "Setting up PersoDub" screen appears and the engines install
+automatically (30 minutes to 2 hours). It is safe to quit during this — reopening the
+app resumes where it left off. Installed this way, the app also keeps itself up to
+date: on launch it checks for a newer release and offers to install it.
+
+Next: [After installing](#after-installing).
+
+---
+
+## macOS — install from source (for developers)
+
+The download above is the recommended way to install. This path builds the app from
+the repository instead — use it if you want to work on PersoDub itself, or if you
+installed this way before (updates on this path arrive by re-running the same
+command).
 
 > Developer tools like Node.js are **prepared automatically by the install command** — no need to install them yourself.
 
@@ -178,9 +201,11 @@ To enable the cloud engines:
 
 ## Updating to a new version later
 
-**macOS.** Run the **same one-line command** you installed with. It fetches the latest code, rebuilds, and replaces the app.
+**On both platforms the app updates itself**: it checks for updates on launch,
+downloads them in the background, and offers **Restart to update** when one is
+ready. You can also update by hand anytime — download the newer file for your
+platform from the [latest release](https://github.com/stronghamjji/PersoDub/releases/latest)
+and install it over the existing app.
 
-**Windows.** The app checks for updates on launch and downloads them in the
-background; when one is ready it offers **Restart to update**. You can also
-update by hand anytime: download the newer `PersoDub-Setup-<version>.exe` from
-the [Releases page](https://github.com/stronghamjji/PersoDub/releases) and run it.
+**Installed from source on macOS?** Run the **same one-line command** you
+installed with. It fetches the latest code, rebuilds, and replaces the app.

--- a/README.md
+++ b/README.md
@@ -31,35 +31,27 @@ never leaves your computer.
 
 ## Installation
 
+Both platforms install the same way: **go to the
+[latest release](https://github.com/stronghamjji/PersoDub/releases/latest)** and
+download the file for your computer.
+
+| Your computer | File to download |
+|---|---|
+| Mac with Apple Silicon (M1 or newer) | `PersoDub-<version>-arm64.dmg` |
+| Windows 10 (21H2+) / 11, 64-bit | `PersoDub-Setup-<version>.exe` |
+
 ### macOS
 
-Apple Silicon Mac. There are two ways to install — pick either.
+Open the downloaded `.dmg` and drag **PersoDub** into your Applications folder. The
+app is signed and notarized, so it opens with a normal double-click, and it keeps
+itself up to date: on launch it checks for a newer release and offers to install it.
 
-#### Option 1 — Download the app (easiest)
-
-Download **`PersoDub-<version>-arm64.dmg`** from the
-[latest release](https://github.com/stronghamjji/PersoDub/releases/latest), open it,
-and drag **PersoDub** into your Applications folder. It is signed and notarized, so it
-opens with a normal double-click. Installed this way, the app keeps itself up to date:
-on launch it checks for a newer release and offers to install it.
-
-#### Option 2 — One line in Terminal
-
-Paste this into Terminal. It fetches the code, installs the prerequisites (including
-Node.js), builds the app, and launches it:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/stronghamjji/PersoDub/HEAD/install.sh | bash
-```
-
-This builds from source; to update later, re-run the same command. Prefer to go step by
-step, starting from installing git and Node.js? See **[INSTALL.md](INSTALL.md)**.
+Developers who prefer to build from source can follow
+[INSTALL.md](INSTALL.md#macos--install-from-source-for-developers).
 
 ### Windows (beta)
 
-Windows 10 (21H2 or newer) or Windows 11, 64-bit. Download
-**`PersoDub-Setup-<version>.exe`** from the
-[latest release](https://github.com/stronghamjji/PersoDub/releases/latest) and run it.
+Run the downloaded **`PersoDub-Setup-<version>.exe`**.
 It installs for your user account only, into `%LOCALAPPDATA%\Programs\PersoDub`, so no
 administrator rights are needed.
 


### PR DESCRIPTION
## Why

Two install paths on macOS forked the guide and doubled the ways a first install can fail. A from-source install just failed in the field on an npm-internal error ("Exit handler never called") that no .dmg user can ever hit, because the .dmg runs neither npm nor Node on the user's machine. Fewer choices, fewer failure modes.

## Changes

- **README**: installation now starts from one shared entry point -- the latest-release page -- with a small table mapping each platform to its file. macOS shows only the .dmg path; the Terminal one-liner is gone from the README and linked as a developer option instead.
- **INSTALL.md**: the macOS section leads with the download-and-drag steps for regular users. The full Terminal flow moves under a new "macOS -- install from source (for developers)" section, kept intact for developers and for existing from-source installs (re-running the command is still how that path updates).
- **Updating**: the section now leads with the self-updater, which installed apps on both platforms share; the re-run-the-command instruction remains for from-source installs.

No behavior changes; documentation only.
