### PR TITLE
Repair a kit whose model download died partway

### DIFF
--- a/desktop/smoke/install-dryrun.test.mjs
+++ b/desktop/smoke/install-dryrun.test.mjs
@@ -72,7 +72,11 @@ test("full install dry run completes, satisfies checkKit, and resumes as all-ski
         mkdirSync(dir, { recursive: true });
         if (dir.includes("HTDemucs")) writeFileSync(join(dir, "955717e8.safetensors"), "");
         if (dir.includes("whisper")) writeFileSync(join(dir, "model.bin"), "");
-        if (dir.includes("qwen3-tts")) writeFileSync(join(dir, "config.json"), "");
+        if (dir.includes("qwen3-tts")) {
+          mkdirSync(join(dir, "speech_tokenizer"), { recursive: true });
+          writeFileSync(join(dir, "model.safetensors"), "");
+          writeFileSync(join(dir, "speech_tokenizer", "model.safetensors"), "");
+        }
       }
       if (joined.includes("whisper.load_model")) {
         mkdirSync(join(cacheDir, "whisper"), { recursive: true });

--- a/desktop/src/engineCheck.js
+++ b/desktop/src/engineCheck.js
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { venvBin, exeName } from "./platform.js";
 import { KIT_ENV } from "./kitEnv.js";
+import { MODEL_MARKERS } from "./installSpec.js";
 
 export const REQUIRED = [
   KIT_ENV,
@@ -17,6 +18,11 @@ export const REQUIRED = [
   // Paths mirror installSpec.js's ollama step (binary + GEMMA_MANIFEST).
   join("ollama", exeName("ollama")),
   "models/ollama/manifests/registry.ollama.ai/library/gemma3/12b",
+  // The HuggingFace models, taken straight from installSpec's own list rather
+  // than copied: the TTS weights went missing from a half-finished install and
+  // nothing here noticed, so boot kept starting a sidecar with no model and
+  // never sent the user back to the installer that would have finished it.
+  ...MODEL_MARKERS.map((rel) => join(...rel)),
 ];
 
 // Reads a KIT_VERSION file (a kit's own, or the app's bundled payload's --

--- a/desktop/src/engineCheck.test.mjs
+++ b/desktop/src/engineCheck.test.mjs
@@ -66,6 +66,17 @@ test("kit missing the pulled Gemma model is not installed", () => {
   assert.deepEqual(res.missing, [manifest]);
 });
 
+// The TTS weights sat outside this check too, so the half-finished install
+// above (installSpec's config.json marker) also passed boot: no model, no
+// working sidecar, and no way back to the installer short of a reinstall.
+test("kit missing the TTS weights is not installed", () => {
+  const weights = join("models", "qwen3-tts", "model.safetensors");
+  const dir = makeKit(REQUIRED.filter((p) => p !== weights), { version: "1.0.0+abc1234" });
+  const res = checkKit(dir, "1.0.0+abc1234");
+  assert.equal(res.ok, false);
+  assert.deepEqual(res.missing, [weights]);
+});
+
 test("nonexistent kitDir reports everything missing", () => {
   const res = checkKit("/nonexistent/kit", "1.0.0+abc1234");
   assert.equal(res.ok, false);

--- a/desktop/src/installSpec.js
+++ b/desktop/src/installSpec.js
@@ -55,29 +55,41 @@ export const GEMMA_MANIFEST = [
 // Each model is pinned to a HuggingFace commit (--revision) the way the
 // Python/CAM++/Ollama downloads are pinned by SHA-256: an upstream repo
 // takeover or force-push must not change what lands on user machines.
+// markers list every weight file a model needs, never the small config files
+// beside them: hf writes each download to a temp name and renames it only
+// once complete, so a weight present at its real path is a finished file --
+// while a config.json arrives seconds in and proves nothing about the rest.
 const MODELS = [
   {
     name: "Demucs (81 MB)",
     dir: ["models", "demucs", "HTDemucs"],
-    marker: ["models", "demucs", "HTDemucs", "955717e8.safetensors"],
+    markers: [["models", "demucs", "HTDemucs", "955717e8.safetensors"]],
     args: ["adefossez/HTDemucs", "htdemucs.yaml", "955717e8.safetensors"],
     revision: "bf35a81b663819a8255c8fefee17f9d812b786b5",
   },
   {
     name: "Whisper large-v3 (2.9 GB)",
     dir: ["models", "whisper", "faster-whisper-large-v3"],
-    marker: ["models", "whisper", "faster-whisper-large-v3", "model.bin"],
+    markers: [["models", "whisper", "faster-whisper-large-v3", "model.bin"]],
     args: ["Systran/faster-whisper-large-v3"],
     revision: "edaa852ec7e145841d8ffdb056a99866b5f0a478",
   },
   {
     name: "Qwen3-TTS (4.3 GB)",
     dir: ["models", "qwen3-tts"],
-    marker: ["models", "qwen3-tts", "config.json"],
+    markers: [
+      ["models", "qwen3-tts", "model.safetensors"],
+      ["models", "qwen3-tts", "speech_tokenizer", "model.safetensors"],
+    ],
     args: ["Qwen/Qwen3-TTS-12Hz-1.7B-Base"],
     revision: "fd4b254389122332181a7c3db7f27e918eec64e3",
   },
 ];
+
+// The same paths engineCheck requires at boot -- one list, so "the install is
+// done" and "the kit is usable" can never disagree the way they did when only
+// this file knew about the models.
+export const MODEL_MARKERS = MODELS.flatMap((m) => m.markers);
 
 // Mirrors openai-whisper's own load_model() default: XDG_CACHE_HOME (if set)
 // joined with "whisper", else ~/.cache/whisper -- verified against the
@@ -172,6 +184,7 @@ function withMissingKitEnvKeys(text) {
 
 export function buildSteps(ctx) {
   const k = (...p) => join(ctx.kitDir, ...p);
+  const modelDone = (m) => m.markers.every((rel) => existsSync(k(...rel)));
   const py = standalonePython(k("python"));
   // Per-platform pinned dependency lists (bundled by collect-payload.mjs).
   const reqSuffix = IS_WIN ? "win" : "mac";
@@ -306,11 +319,11 @@ export function buildSteps(ctx) {
     {
       id: "models",
       title: "Downloading AI models (~7 GB)",
-      isDone: () => MODELS.every((m) => existsSync(k(...m.marker))),
+      isDone: () => MODELS.every(modelDone),
       run: async (report) => {
         const hf = venvBin(k("qwen_venv"), "hf");
         for (const m of MODELS) {
-          if (existsSync(k(...m.marker))) continue;
+          if (modelDone(m)) continue;
           report(null, `Downloading ${m.name}`);
           mkdirSync(k(...m.dir), { recursive: true });
           await ctx.run([hf, "download", ...m.args, "--revision", m.revision, "--local-dir", k(...m.dir)], {

--- a/desktop/src/installSpec.test.mjs
+++ b/desktop/src/installSpec.test.mjs
@@ -220,7 +220,11 @@ test("models step skips models whose marker exists", async () => {
     const dir = argv[dirIdx];
     mkdirSync(dir, { recursive: true });
     if (dir.includes("whisper")) writeFileSync(join(dir, "model.bin"), "");
-    if (dir.includes("qwen3-tts")) writeFileSync(join(dir, "config.json"), "");
+    if (dir.includes("qwen3-tts")) {
+      mkdirSync(join(dir, "speech_tokenizer"), { recursive: true });
+      writeFileSync(join(dir, "model.safetensors"), "");
+      writeFileSync(join(dir, "speech_tokenizer", "model.safetensors"), "");
+    }
   };
   const step = byId(ctx).models;
   assert.equal(await step.isDone(), false);
@@ -228,6 +232,50 @@ test("models step skips models whose marker exists", async () => {
   assert.equal(hfCalls.length, 2, "demucs must be skipped");
   assert.ok(hfCalls.every((a) => !a.join(" ").includes("HTDemucs")));
   assert.equal(await step.isDone(), true);
+});
+
+// The TTS model's only marker used to be config.json -- 4.5 KB that lands
+// seconds into a 4.3 GB download. An install killed just after it left the
+// step "done" forever: this isDone skipped the model on every later run, and
+// engineCheck (which never looked at model files) reported the kit installed,
+// so boot went straight to a sidecar with no weights and failed every time.
+test("models step is not done until every model's weight file exists", () => {
+  const ctx = freshCtx();
+  const put = (...rel) => {
+    mkdirSync(join(ctx.kitDir, ...rel.slice(0, -1)), { recursive: true });
+    writeFileSync(join(ctx.kitDir, ...rel), "");
+  };
+  put("models", "demucs", "HTDemucs", "955717e8.safetensors");
+  put("models", "whisper", "faster-whisper-large-v3", "model.bin");
+  put("models", "qwen3-tts", "config.json");
+  assert.equal(byId(ctx).models.isDone(), false, "config.json alone is not the model");
+  put("models", "qwen3-tts", "model.safetensors");
+  assert.equal(byId(ctx).models.isDone(), false, "speech_tokenizer weights still missing");
+  put("models", "qwen3-tts", "speech_tokenizer", "model.safetensors");
+  assert.equal(byId(ctx).models.isDone(), true);
+});
+
+test("models step re-downloads the TTS model when only its config landed", async () => {
+  const ctx = freshCtx();
+  const put = (...rel) => {
+    mkdirSync(join(ctx.kitDir, ...rel.slice(0, -1)), { recursive: true });
+    writeFileSync(join(ctx.kitDir, ...rel), "");
+  };
+  put("models", "demucs", "HTDemucs", "955717e8.safetensors");
+  put("models", "whisper", "faster-whisper-large-v3", "model.bin");
+  put("models", "qwen3-tts", "config.json");
+  const hfCalls = [];
+  ctx.run = async (argv) => {
+    hfCalls.push(argv);
+    const dir = argv[argv.indexOf("--local-dir") + 1];
+    mkdirSync(join(dir, "speech_tokenizer"), { recursive: true });
+    writeFileSync(join(dir, "model.safetensors"), "");
+    writeFileSync(join(dir, "speech_tokenizer", "model.safetensors"), "");
+  };
+  await byId(ctx).models.run(() => {});
+  assert.equal(hfCalls.length, 1, "only the TTS model is re-downloaded");
+  assert.ok(hfCalls[0].join(" ").includes("Qwen/Qwen3-TTS"), hfCalls[0].join(" "));
+  assert.equal(byId(ctx).models.isDone(), true);
 });
 
 // A missing "base" model means every laugh/breath in a dub gets silently


### PR DESCRIPTION
## What was broken

The TTS model step judged itself complete by a single 4.5 KB `config.json`, a file that arrives seconds into a 4.3 GB download, and no model file appeared on `engineCheck`'s required list.

An install killed just after that config landed was then unrecoverable. The models step skipped the download on every later run, `checkKit` reported the kit installed, and boot went straight to a sidecar with no weights -- failing on every launch with no path back to the installer. `INSTALL.md` tells users it is safe to close the app mid-setup, which walks them into exactly this state.

## What changed

- Each model now lists every weight file it needs (`markers`), never the small config files beside them. `hf` writes each download to a temp name and renames it only once complete, so a weight present at its real path is a finished file.
- `engineCheck.REQUIRED` takes those same paths from `installSpec`'s own list rather than a hand-copied duplicate, so the install's "done" test and boot's "installed" test cannot drift apart -- the drift that caused this bug.

A kit missing model weights now fails the boot check, re-enters the installer, and the resume logic downloads only what is absent. Nothing else re-downloads.

## Verification

- Full desktop suite: 100 tests pass. Three new tests fail against the old code and pass against this change.
- The smoke dry run (full install then `checkKit`) covers the two lists agreeing.
- On a real macOS install: a healthy kit still passes (no false alarm for existing users); removing the Demucs weights (84 MB) and the TTS speech-tokenizer weights (650 MB) each sent the app to the setup screen, which re-downloaded only the missing file and returned to the normal window.
- Windows is covered by CI only; not exercised on hardware.