### PR TITLE
Stop installs that cannot fit, name what actually failed, and tidy job output

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,8 @@ the check off entirely.
 
 PersoDub reports four events — app launch, dub finished, dub failed, install failed —
 to see how many installs finish a dub. Each carries the app version, your operating
-system, a random install ID, and on a failure one short code off a fixed list. Never
+system, a random install ID, and on a failure one short code off a fixed list. A failed
+install also names which of its ten steps it stopped at, again off a fixed list. Never
 your video, audio, subtitles, filenames, paths or error text; no IP address is stored.
 
 A launch counts once a day; every dub counts. Turn it off in **Settings → Privacy** or

--- a/analytics/schema.sql
+++ b/analytics/schema.sql
@@ -8,7 +8,8 @@ CREATE TABLE IF NOT EXISTS events (
   os         TEXT NOT NULL,  -- mac | windows
   version    TEXT NOT NULL,  -- e.g. 0.3.2
   device     TEXT NOT NULL,  -- random install id, 32 hex chars
-  error_code TEXT            -- failure events only; NULL otherwise
+  error_code TEXT,           -- failure events only; NULL otherwise
+  step       TEXT            -- install failures only; NULL before app 0.3.6
 );
 
 CREATE INDEX IF NOT EXISTS idx_events_day    ON events (day);

--- a/analytics/src/index.js
+++ b/analytics/src/index.js
@@ -9,8 +9,16 @@ const EVENTS = new Set(["app_launch", "dub_success", "dub_failure", "install_fai
 const PLATFORMS = new Set(["mac", "windows"]);
 const ERROR_CODES = new Set([
   "path-too-long", "disk-full", "network", "permission", "engine-start",
-  "out-of-memory", "unsupported-format", "engine-crash",
+  "out-of-memory", "unsupported-format", "engine-crash", "step-failed",
   "unknown",
+]);
+
+// The ten install steps, exactly as desktop/src/installSpec.js names them. An
+// install failure says which one it died in; "engine-crash" alone meant
+// "somewhere in ten steps" and could not be acted on.
+const STEPS = new Set([
+  "payload", "python", "venv-app", "venv-engines", "ffmpeg", "venv-qwen",
+  "models", "gemma", "nonverbal-weights", "kit-env",
 ]);
 
 const DEVICE = /^[0-9a-f]{32}$/;
@@ -44,9 +52,17 @@ export default {
     // should not land rows in the wrong bucket for everyone else.
     const day = new Date().toISOString().slice(0, 10);
 
+    // Only install failures carry a step, and only a published id -- an
+    // unrecognized value becomes "unknown" rather than reaching the table, the
+    // same rule the error code follows. Versions before 0.3.6 send none at all,
+    // which stores NULL: the column has to stay optional for them.
+    const step = (event === "install_failure" && body.step !== undefined)
+      ? (STEPS.has(body.step) ? body.step : "unknown")
+      : null;
+
     await env.persodub_count
-      .prepare("INSERT INTO events (day, event, os, version, device, error_code) VALUES (?, ?, ?, ?, ?, ?)")
-      .bind(day, event, os, version, device, code)
+      .prepare("INSERT INTO events (day, event, os, version, device, error_code, step) VALUES (?, ?, ?, ?, ?, ?, ?)")
+      .bind(day, event, os, version, device, code, step)
       .run();
 
     return new Response(null, { status: 204 });

--- a/app/dub_script.py
+++ b/app/dub_script.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""Reading, measuring and editing one job's dubbing script.
+
+Knows nothing about MCP or HTTP -- app/mcp_server.py only calls these functions.
+That keeps the tests pure logic over files, with no external service running
+(docs/development.md).
+
+The files this works with, all inside one job's work dir:
+  original.srt    the source script, kept by app/pipeline.py just before the
+                  translation overwrites it in place
+  translated.srt  the script the dub actually read. Never edited.
+  edited.srt      the edited script. Absent until something is edited.
+"""
+import os
+from typing import List, Optional
+
+from app.text.cues import match_cue_index
+from app.text.length_fit import in_window
+from app.text.srt import Cue, estimate_seconds, parse_srt
+
+ORIGINAL_NAME = "original.srt"
+DUB_NAME = "translated.srt"
+EDITED_NAME = "edited.srt"
+
+
+def _read_cues(path: str) -> List[Cue]:
+    """Parse an SRT file, or return nothing at all if it is not there."""
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8-sig") as f:
+        return parse_srt(f.read())
+
+
+def script_path(work_dir: str) -> str:
+    """The script that currently counts: the edited one if it exists, else the dubbed one."""
+    edited = os.path.join(work_dir, EDITED_NAME)
+    if os.path.exists(edited):
+        return edited
+    return os.path.join(work_dir, DUB_NAME)
+
+
+def load_lines(work_dir: str, lang: str) -> List[dict]:
+    """One entry per script line, each carrying the source line that overlaps it in time.
+
+    Pairing is by time, not by line number: sentence splitting and time borrowing run
+    after translation (app/pipeline.py:235-237), so the two files can have different
+    line counts. app.text.cues.match_cue_index finds the source line a given line's
+    midpoint falls inside -- one source split into two translated lines leaves both
+    halves pointing at the same source.
+    """
+    path = script_path(work_dir)
+    if not os.path.exists(path):
+        raise FileNotFoundError("this job has no script: %s" % path)
+
+    cues = _read_cues(path)
+    originals = _read_cues(os.path.join(work_dir, ORIGINAL_NAME))
+
+    lines = []
+    for n, c in enumerate(cues, start=1):
+        slot = round(c["end"] - c["start"], 2)
+        estimated = round(estimate_seconds(c["text"], lang), 2)
+        k = match_cue_index(c, originals) if originals else None
+        lines.append({
+            "line": n,
+            "start": round(c["start"], 2),
+            "end": round(c["end"], 2),
+            "slot": slot,
+            "source": originals[k]["text"] if k is not None else None,
+            "text": c["text"],
+            "estimated": estimated,
+            "fits": in_window(estimated, slot),
+        })
+    return lines

--- a/app/dub_script.py
+++ b/app/dub_script.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 
 from app.text.cues import match_cue_index
 from app.text.length_fit import in_window
-from app.text.srt import Cue, estimate_seconds, parse_srt
+from app.text.srt import Cue, build_srt, estimate_seconds, parse_srt
 
 ORIGINAL_NAME = "original.srt"
 DUB_NAME = "translated.srt"
@@ -71,3 +71,41 @@ def load_lines(work_dir: str, lang: str) -> List[dict]:
             "fits": in_window(estimated, slot),
         })
     return lines
+
+
+def edit_line(work_dir: str, line: int, text: str, lang: str) -> dict:
+    """Rewrite line number `line` (1-based) as `text`, and report that line back.
+
+    Always writes to edited.srt. translated.srt is the record of what the dub actually
+    read -- overwrite it and there is nothing left to compare an edit against.
+    Timing is never touched: shifting a line pulls the voice out of sync with the mouth.
+    """
+    cues = _read_cues(script_path(work_dir))
+    if not cues:
+        raise FileNotFoundError("this job has no script: %s" % work_dir)
+    if not 1 <= line <= len(cues):
+        raise ValueError(
+            "there is no line %d -- this script runs from line 1 to %d" % (line, len(cues))
+        )
+
+    cues[line - 1]["text"] = text
+    with open(os.path.join(work_dir, EDITED_NAME), "w", encoding="utf-8") as f:
+        f.write(build_srt(cues))
+
+    return load_lines(work_dir, lang)[line - 1]
+
+
+def export_srt(work_dir: str, out_path: str) -> str:
+    """Copy the script that currently counts to out_path, and return that path.
+
+    Feeding this file back in as a ready-made translated SRT (app/main.py:303) skips
+    transcription and translation, so only the voices are made again.
+    """
+    src = script_path(work_dir)
+    if not os.path.exists(src):
+        raise FileNotFoundError("this job has no script: %s" % work_dir)
+    with open(src, encoding="utf-8-sig") as f:
+        body = f.read()
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(body)
+    return out_path

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import uuid
+from datetime import date
 from typing import List, Optional
 from urllib.parse import urlparse
 
@@ -29,6 +30,7 @@ from app.engines_status import (
 from app.jobs import JobStore
 from app.perso_client import APP_VERSION, SIGNUP_LINK, list_dubbing_spaces
 from app.pipeline import run_dub
+from app.text.naming import next_free, safe_name
 from app.settings_env import (read_analytics_off, read_key_status, read_value,
                               write_analytics_off, write_keys)
 from app.source_fetch import FetchError, fetch as fetch_source, probe as probe_source
@@ -309,6 +311,7 @@ def dub_start(
     stt_engine: Optional[str] = Form(None),
     n_takes: Optional[int] = Form(None),
     source_language_code: Optional[str] = Form(None),
+    project: Optional[str] = Form(None),
 ):
     """Start dubbing by uploading a video (+ optional subtitles) from the screen.
 
@@ -371,8 +374,16 @@ def dub_start(
                 "Select a Perso workspace in Settings.",
             )
 
-    work = os.path.join(WORKSPACE, uuid.uuid4().hex[:8])
-    os.makedirs(work, exist_ok=True)
+    # Names the job's folder. The caller may pass a title it already knows (the
+    # screen probes a link before starting, and app/source_fetch.py's fetch()
+    # returns nothing, so the server never learns it otherwise). Without one,
+    # fall back to the uploaded filename or the URL.
+    project = safe_name(project or "")
+    if not project:
+        project = safe_name(
+            os.path.splitext(video.filename or "")[0] if has_upload else (source_url or "")
+        )
+    work = _job_dir(project, language_code)
     video_path = os.path.join(work, "input.mp4")
     if has_upload:
         with open(video_path, "wb") as f:
@@ -393,7 +404,14 @@ def dub_start(
     jid = job_store.create()
     # The download filenames are built from this; the job record is the only
     # place the result endpoints can read the user's choice back from.
-    job_store._update(jid, language_code=language_code)
+    # project/day/from_link are read back by the download endpoints and by the
+    # desktop shell, which builds the save folder from them. `day` is stamped
+    # here rather than recomputed later: a job started at 23:59 must not land in
+    # tomorrow's folder when it finishes.
+    job_store._update(jid, language_code=language_code,
+                      project=project or os.path.basename(work),
+                      day=_today(),
+                      from_link=bool(source_url))
     # First log line names the source -- log files are job-<id>.log, so without
     # this there is no way to tell which video a log belongs to.
     job_store.append_log(jid, f"🎬 {source_url or video.filename or 'video'}")
@@ -459,6 +477,37 @@ def translate_api(body: TranslateRequest):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Translation failed: {e}")
     return {"translations": out}
+
+
+def _today():
+    # type: () -> str
+    """Today as YYYY-MM-DD. Split out so tests can pin the date."""
+    return date.today().isoformat()
+
+
+def _job_dir(title, lang_code):
+    # type: (str, str) -> str
+    """Create and return this job's workspace folder.
+
+    Named <date>/<title>_<lang> so the folder says what it holds -- the old
+    random hex said nothing. The language is part of the name because each
+    language is a separate job with its own video, script and voice pieces;
+    sharing one folder would overwrite them.
+
+    Falls back to the old random name whenever a usable title cannot be built
+    (unusable characters, empty title, or 999 runs of the same name today).
+    """
+    day = os.path.join(WORKSPACE, _today())
+    os.makedirs(day, exist_ok=True)
+
+    base = safe_name(title)
+    name = next_free("%s_%s" % (base, lang_code), os.listdir(day)) if base else None
+    if name is None:
+        name = uuid.uuid4().hex[:8]
+
+    work = os.path.join(day, name)
+    os.makedirs(work, exist_ok=True)
+    return work
 
 
 def _target_code(job: dict) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -264,6 +264,32 @@ def dub_job_cancel(jid: str):
     return {"job_id": jid, "status": status}
 
 
+@app.delete("/api/dub/jobs/{jid}/workspace")
+def dub_job_delete_workspace(jid: str):
+    """Delete a job's whole folder. Irreversible, so the screen asks first.
+
+    Automatic cleanup (app/pipeline.py's cleanup_intermediates) only drops the
+    audio a finished job no longer needs; deleting the results themselves is
+    always the user's own call.
+    """
+    j = job_store.get(jid)
+    if j is None:
+        raise HTTPException(status_code=404, detail=f"Unknown job: {jid}")
+    if j["status"] == "running":
+        raise HTTPException(status_code=409, detail="Job is still running")
+    out = (j.get("result") or {}).get("out_path")
+    if not out:
+        raise HTTPException(status_code=404, detail="Nothing to delete")
+    work = os.path.abspath(os.path.dirname(out))
+    root = os.path.abspath(WORKSPACE)
+    # A job record is the only thing naming this path; refuse anything that
+    # somehow points outside the workspace rather than trusting it.
+    if os.path.commonpath([work, root]) != root or work == root:
+        raise HTTPException(status_code=400, detail="Refusing to delete outside the workspace")
+    shutil.rmtree(work, ignore_errors=True)
+    return {"job_id": jid, "deleted": True}
+
+
 @app.get("/api/engines")
 def engines_status():
     """Which translation/transcription engines actually work on this machine right now.

--- a/app/main.py
+++ b/app/main.py
@@ -526,26 +526,30 @@ def dub_result(jid: str):
     if not out or not os.path.exists(out):
         raise HTTPException(status_code=404, detail="Result file not found")
     return FileResponse(out, media_type="video/mp4",
-                        filename=f"dubbed_{_target_code(j)}.mp4")
+                        filename=f"dub_{_target_code(j)}.mp4")
 
 
 @app.get("/api/dub/result/{jid}/original")
 def dub_result_original(jid: str):
-    """Return the source video the job worked from.
+    """Return the source video a link job downloaded.
 
-    Same file for both entry paths: an upload is copied to input.mp4 and a
-    fetched link is written to input.mp4, so this needs no special case.
+    Only offered for link jobs. A file the user uploaded is already on their
+    machine, so handing it back is pure noise; a video pulled from a link is
+    the only original they cannot otherwise get.
     """
     j = job_store.get(jid)
     if j is None:
         raise HTTPException(status_code=404, detail=f"Unknown job: {jid}")
+    if not j.get("from_link"):
+        raise HTTPException(status_code=404,
+                            detail="This job started from a file you already have")
     out = (j.get("result") or {}).get("out_path")
     if not out:
         raise HTTPException(status_code=404, detail="Result file not found")
     original = os.path.join(os.path.dirname(out), "input.mp4")
     if not os.path.exists(original):
         raise HTTPException(status_code=404, detail="Original file not found")
-    return FileResponse(original, media_type="video/mp4", filename="original.mp4")
+    return FileResponse(original, media_type="video/mp4", filename="org.mp4")
 
 
 @app.get("/api/dub/result/{jid}/srt")
@@ -574,7 +578,7 @@ def dub_result_srt(jid: str, download: int = 0):
             headers = None
             if download:
                 headers = {"Content-Disposition":
-                           f'attachment; filename="dubbed_{_target_code(j)}.srt"'}
+                           f'attachment; filename="dub_{_target_code(j)}.srt"'}
             return Response(content=text,
                             media_type="text/plain; charset=utf-8",
                             headers=headers)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import uuid
 from datetime import date
@@ -365,6 +366,8 @@ def dub_start(
     stt_engine = (stt_engine or "").strip().lower() or None
     if stt_engine not in (None, "local", "perso"):
         raise HTTPException(422, f"Unknown stt_engine: {stt_engine}")
+    if not _valid_language_code(language_code):
+        raise HTTPException(422, f"Unknown language_code: {language_code}")
     effective_translate_engine = (translate_engine or TRANSLATE_ENGINE or "").lower()
     if effective_translate_engine == "gemma":
         status = gemma_status()
@@ -511,6 +514,16 @@ def _today():
     return date.today().isoformat()
 
 
+# A language code, not a path fragment: letters, then optionally a region after
+# a hyphen or underscore ("ko", "zh-CN", "pt_BR", "es-419"). Nothing else gets
+# in, because _job_dir pastes this straight into the job's folder name.
+_LANGUAGE_CODE = re.compile(r"^[A-Za-z]{2,8}([-_][A-Za-z0-9]{2,8})?$")
+
+
+def _valid_language_code(code: str) -> bool:
+    return bool(_LANGUAGE_CODE.match(code or ""))
+
+
 def _job_dir(title, lang_code):
     # type: (str, str) -> str
     """Create and return this job's workspace folder.
@@ -527,7 +540,12 @@ def _job_dir(title, lang_code):
     os.makedirs(day, exist_ok=True)
 
     base = safe_name(title)
-    name = next_free("%s_%s" % (base, lang_code), os.listdir(day)) if base else None
+    # The language half is caller-supplied too, and went in unchecked while the
+    # title half was sanitized -- so "../.." in it walked the job out of the
+    # workspace and wrote input.mp4 over whatever lived there. dub_start
+    # rejects a malformed code outright; this keeps every other caller safe.
+    lang = safe_name(lang_code) or "out"
+    name = next_free("%s_%s" % (base, lang), os.listdir(day)) if base else None
     if name is None:
         name = uuid.uuid4().hex[:8]
 

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""A small program that hands PersoDub's script tools to a terminal AI over MCP.
+
+Not a web server. It talks over stdin/stdout only, on this machine, and dies with
+whatever started it. Nothing leaves the machine.
+
+Run it with:
+    PERSODUB_API=http://127.0.0.1:8000 python -m app.mcp_server
+
+See docs/superpowers/specs/2026-08-20-앱내터미널-설계.md for wiring it into a
+terminal tool.
+
+What is not here cannot be reached. Starting or cancelling a dub, changing settings
+and deleting files are deliberately absent -- anything that spends the GPU and a lot
+of time stays behind a button a person presses.
+"""
+import os
+from typing import List, Optional
+
+import httpx
+from mcp.server.mcpserver import MCPServer
+
+from app.dub_script import edit_line, export_srt, load_lines
+
+API = os.environ.get("PERSODUB_API", "http://127.0.0.1:8000")
+
+mcp = MCPServer(
+    name="persodub",
+    instructions=(
+        "Tools for reading and rewriting a PersoDub dubbing script. In PersoDub a "
+        "script is not on-screen subtitles -- it is what a voice actor reads, so "
+        "changing the words changes the audio. Every line has a fixed slot of time, "
+        "and a line too long to be spoken inside it has fits=false."
+    ),
+)
+
+
+def _job(job_id: str) -> dict:
+    """Ask the app server about a job."""
+    r = httpx.get("%s/api/dub/jobs/%s" % (API, job_id), timeout=10.0)
+    if r.status_code == 404:
+        raise ValueError("no such job: %s" % job_id)
+    r.raise_for_status()
+    return r.json()
+
+
+def _work_dir(job: dict) -> str:
+    """A job's workspace folder.
+
+    The folder name and the job id are two unrelated random strings (app/main.py:374
+    and :379), so the folder cannot be derived from the id -- it is read back out of
+    the result path, the same way app/main.py:516 does it.
+    """
+    out = (job.get("result") or {}).get("out_path")
+    if not out:
+        raise ValueError("this job has no result yet (status: %s)" % job.get("status"))
+    return os.path.dirname(out)
+
+
+def _lang(job: dict) -> str:
+    """The dub's target language, stamped onto the job by app/main.py:396."""
+    return job.get("language_code") or "en"
+
+
+@mcp.tool()
+def get_script(job_id: str) -> List[dict]:
+    """Return the dubbing script line by line.
+
+    Each line carries: line (its number), start/end (seconds), slot (the time this
+    line has to be spoken in), source (the original-language line), text (the current
+    translation), estimated (how long the translation takes to say), and fits (true
+    when estimated lands inside the slot).
+    """
+    job = _job(job_id)
+    return load_lines(_work_dir(job), _lang(job))
+
+
+@mcp.tool()
+def edit_script_line(job_id: str, line: int, text: str) -> dict:
+    """Replace one line's words. Timing is left alone.
+
+    What the dub actually read (translated.srt) is never touched -- edits are kept
+    separately. Returns the edited line, so its fits tells you at once whether the
+    new wording is short enough.
+    """
+    job = _job(job_id)
+    return edit_line(_work_dir(job), line, text, _lang(job))
+
+
+@mcp.tool()
+def check_fit(job_id: str, line: Optional[int] = None) -> List[dict]:
+    """Measure whether lines can be spoken inside the time they have.
+
+    With a line number, reports just that line; without one, reports every line that
+    does not fit.
+    """
+    job = _job(job_id)
+    lines = load_lines(_work_dir(job), _lang(job))
+    if line is not None:
+        if not 1 <= line <= len(lines):
+            raise ValueError(
+                "there is no line %d -- this script runs from line 1 to %d" % (line, len(lines))
+            )
+        return [lines[line - 1]]
+    return [ln for ln in lines if not ln["fits"]]
+
+
+@mcp.tool()
+def export_script(job_id: str, out_path: str) -> str:
+    """Write the current script out to a file and return that path.
+
+    Feeding that file back into PersoDub as a ready-made translated subtitle skips
+    transcription and translation, and makes the voices again from this script.
+    """
+    job = _job(job_id)
+    return export_srt(_work_dir(job), out_path)
+
+
+@mcp.tool()
+def get_job_status(job_id: str) -> dict:
+    """Where the job is now, whether it finished, and what happened along the way."""
+    job = _job(job_id)
+    return {
+        "status": job.get("status"),
+        "error": job.get("error"),
+        "notices": job.get("notices") or [],
+        "logs": (job.get("logs") or [])[-20:],
+    }
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -229,6 +229,13 @@ def _auto_translate_srt(
     if still_bad:
         log(f"   ⚠️ {len(still_bad)} lines still not in the target language — output needs review")
 
+    # Keep the source script before the next line overwrites it in place -- past this
+    # point the source is gone, and app/dub_script.py needs it to show a line's source
+    # next to its translation. Named original.srt, not source.srt: source.srt already
+    # belongs to a caller-uploaded source script (app/main.py:388).
+    with open(os.path.join(work_dir, "original.srt"), "w", encoding="utf-8") as f:
+        f.write(build_srt(cues))
+
     for c, tr in zip(cues, translated):
         c["text"] = tr
     # Split translated blocks into sentences to fine-tune dubbing timing

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -6,6 +6,7 @@ Every stage runs locally or through our own Qwen3-TTS sidecar -- no third-party
 container anywhere in this app.
 """
 import os
+import re
 import subprocess
 import tempfile
 import uuid
@@ -557,6 +558,7 @@ def run_dub(
     # candidates that were kept for a possible reassembly pass (see
     # qwen_pipeline.synth_lines / cleanup_takes).
     cleanup_takes(work_dir, log)
+    cleanup_intermediates(work_dir, log)
     log("✅ Done!")
     return {
         "job_id": job_id,
@@ -565,3 +567,30 @@ def run_dub(
         "auto_translated": auto_translated,
         "detected_source_language": detected_language["code"],
     }
+
+
+_INTERMEDIATE = re.compile(
+    r"^(vocals|background|qwen_dub_48k|qwen_line_\d+|qwen_ref_.*)\.wav$"
+)
+
+
+def cleanup_intermediates(work_dir, log=None):
+    # type: (str, Optional[Callable[[str], None]]) -> int
+    """Delete the audio a finished job no longer needs. Returns how many went.
+
+    Call ONLY after the job succeeded -- a failed or cancelled job keeps
+    everything, because that is what tells us what went wrong. Measured on a
+    real job (2026-08-21): about 61% of a 31MB folder. The dubbed video, the
+    source video and every .srt are never touched.
+    """
+    log = log or (lambda m: None)
+    if not os.path.isdir(work_dir):
+        return 0
+    removed = 0
+    for name in os.listdir(work_dir):
+        if _INTERMEDIATE.match(name):
+            os.remove(os.path.join(work_dir, name))
+            removed += 1
+    if removed:
+        log("   cleaned up %d intermediate audio file(s)" % removed)
+    return removed

--- a/app/text/naming.py
+++ b/app/text/naming.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Turning a video's title into a folder name a filesystem will accept.
+
+Pure string work -- knows nothing about files or HTTP, so the tests run with
+nothing else present (docs/development.md).
+"""
+import re
+import unicodedata
+from typing import Iterable, Optional
+
+# Characters a path cannot hold on macOS or Windows, plus the control range.
+_ILLEGAL = re.compile(r'[/\\:*?"<>|\x00-\x1f]')
+MAX_COUNTER = 999
+
+
+def safe_name(raw, max_len=80):
+    # type: (str, int) -> str
+    """A folder-safe version of `raw`, or "" when nothing usable is left.
+
+    Normalizes to NFC first: macOS hands back decomposed Korean (NFD), and a
+    folder created under one form is not found by a name built under the other.
+    An empty result means the caller should fall back to a random name.
+    """
+    if not raw:
+        return ""
+    name = unicodedata.normalize("NFC", raw)
+    name = _ILLEGAL.sub("", name)
+    name = re.sub(r"\s+", " ", name).strip(" .")
+    return name[:max_len].strip(" .")
+
+
+def next_free(base, taken):
+    # type: (str, Iterable[str]) -> Optional[str]
+    """`base`, or `base_001`.. if it is taken. None once three digits run out."""
+    used = set(taken)
+    if base not in used:
+        return base
+    for n in range(1, MAX_COUNTER + 1):
+        candidate = "%s_%03d" % (base, n)
+        if candidate not in used:
+            return candidate
+    return None

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,6 +1,6 @@
-import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, session, shell } from "electron";
 import { join, dirname } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { parseEnvFile, KIT_ENV, migrateKitEnv } from "./src/kitEnv.js";
 import { fileURLToPath } from "node:url";
 import { loadConfig, DEFAULTS, defaultKitDir, kitPathTooLong } from "./src/config.js";
@@ -9,6 +9,7 @@ import { killStalePids, startEngines } from "./src/orchestrator.js";
 import { buildSteps } from "./src/installSpec.js";
 import { runInstall } from "./src/installer.js";
 import { download } from "./src/download.js";
+import { uniqueName } from "./src/downloadPath.js";
 import { extractTarGz } from "./src/extract.js";
 import { run } from "./src/exec.js";
 import { pullOllamaModel } from "./src/ollamaPull.js";
@@ -224,10 +225,38 @@ async function boot(win) {
   }
 }
 
+// Filled by the screen when it renders a finished job, read back synchronously
+// inside will-download (which cannot await a fetch).
+const jobFolders = new Map();
+ipcMain.on("shell:remember-job", (_e, job) => {
+  if (job && job.id && job.project && job.day) {
+    jobFolders.set(job.id, { project: job.project, day: job.day });
+  }
+});
+
 app.whenReady().then(() => {
   // One greppable line naming the running version -- the e2e update test (and
   // any future bug report) reads it instead of guessing from filenames.
   console.log(`PERSODUB_VERSION ${app.getVersion()}`);
+
+  // The app server names the file (dub_en.mp4); the folder comes from the job's
+  // date and project, so three episodes do not collapse into "dub_en (1).mp4".
+  // Nothing here is fatal: on any failure Electron picks the path the way it
+  // always did -- which is also what happens when the UI runs in a plain
+  // browser and never sent us the job.
+  session.defaultSession.on("will-download", (_event, item) => {
+    try {
+      const jid = new URL(item.getURL()).pathname.split("/")[4];
+      const folder = jid && jobFolders.get(jid);
+      if (!folder) return;
+      const dir = join(app.getPath("downloads"), folder.day, folder.project);
+      mkdirSync(dir, { recursive: true });
+      const name = uniqueName(item.getFilename(), (n) => existsSync(join(dir, n)));
+      if (name) item.setSavePath(join(dir, name));
+    } catch {
+      /* fall through to Electron's default naming */
+    }
+  });
   const win = new BrowserWindow({
     width: 1200,
     height: 800,

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -3,10 +3,10 @@ import { join, dirname } from "node:path";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { parseEnvFile, KIT_ENV, migrateKitEnv } from "./src/kitEnv.js";
 import { fileURLToPath } from "node:url";
-import { loadConfig, DEFAULTS, defaultKitDir, kitPathTooLong } from "./src/config.js";
+import { loadConfig, DEFAULTS, defaultKitDir, kitPathTooLong, notEnoughSpace, freeSpaceAt } from "./src/config.js";
 import { checkKit, readKitVersion } from "./src/engineCheck.js";
 import { killStalePids, startEngines } from "./src/orchestrator.js";
-import { buildSteps } from "./src/installSpec.js";
+import { buildSteps, bytesStillNeeded } from "./src/installSpec.js";
 import { runInstall } from "./src/installer.js";
 import { download } from "./src/download.js";
 import { uniqueName } from "./src/downloadPath.js";
@@ -45,7 +45,7 @@ function analyticsMode(kitDir) {
   return resolveAnalyticsMode({ isPackaged: app.isPackaged, env });
 }
 
-function countUsage(event, kitDir, errorCode) {
+function countUsage(event, kitDir, errorCode, step) {
   try {
     const mode = analyticsMode(kitDir);
     if (mode === "off") return;
@@ -56,6 +56,7 @@ function countUsage(event, kitDir, errorCode) {
       os: IS_WIN ? "windows" : "mac",
       version: app.getVersion(),
       errorCode,
+      step,
     });
   } catch { /* a count is never worth interrupting a launch for */ }
 }
@@ -182,20 +183,46 @@ async function boot(win) {
       if (tooLong) {
         countUsage("install_failure", cfg.kitDir, "path-too-long");
         await win.loadFile(join(HERE, "screens", "error.html"), {
-          query: { message: tooLong, logDir: cfg.kitDir },
+          // No logDir: this stopped before a byte was written, so there is no
+          // log to point at.
+          query: { title: "Choose a shorter install location", message: tooLong },
+        });
+        return;
+      }
+      const ctx = { kitDir: cfg.kitDir, payloadDir: payload, download, extract: extractTarGz, run, pullOllama: pullOllamaModel };
+      const steps = buildSteps(ctx);
+      // The other preflight, and for the same reason: five machines reported a
+      // disk-full from deep inside a step, after gigabytes had already been
+      // downloaded. Only the steps still missing are counted, so a half-done
+      // install asks for the remainder rather than the whole kit again.
+      const noRoom = notEnoughSpace(await bytesStillNeeded(steps), await freeSpaceAt(cfg.kitDir));
+      if (noRoom) {
+        countUsage("install_failure", cfg.kitDir, "disk-full");
+        await win.loadFile(join(HERE, "screens", "error.html"), {
+          query: { title: "Not enough space to install", message: noRoom },
         });
         return;
       }
       await win.loadFile(join(HERE, "screens", "installing.html"));
-      const ctx = { kitDir: cfg.kitDir, payloadDir: payload, download, extract: extractTarGz, run, pullOllama: pullOllamaModel };
+      // runInstall already reports which step failed; without keeping it the
+      // count says only "somewhere in ten steps", which is what made the first
+      // four real install failures unactionable.
+      let failedStep;
       try {
-        await runInstall(buildSteps(ctx), {
-          onProgress: (p) => win.webContents.send("shell:install-progress", p),
+        await runInstall(steps, {
+          onProgress: (p) => {
+            if (p.state === "error") failedStep = p.stepId;
+            win.webContents.send("shell:install-progress", p);
+          },
         });
       } catch (err) {
-        countUsage("install_failure", cfg.kitDir, classifyError(String((err && err.message) || err)));
+        countUsage("install_failure", cfg.kitDir, classifyError(String((err && err.message) || err), { install: true }), failedStep);
         await win.loadFile(join(HERE, "screens", "error.html"), {
-          query: { message: String((err && err.message) || err), logDir: cfg.kitDir },
+          query: {
+            title: "The install could not finish",
+            message: String((err && err.message) || err),
+            logDir: cfg.kitDir,
+          },
         });
         return;
       }

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -3,6 +3,10 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("persodubShell", {
   retry: () => ipcRenderer.send("shell:retry"),
+  // Downloads land in <Downloads>/<day>/<project>/, which only the page knows.
+  // Handed over when a finished job is rendered, so will-download (a synchronous
+  // callback that cannot await a fetch) can read it back.
+  rememberJob: (job) => ipcRenderer.send("shell:remember-job", job),
   // Settings' "Restart now" button. Keys/workspace only apply on the next
   // start, and asking a non-technical user to quit and reopen by hand was
   // the step that silently didn't happen.

--- a/desktop/screens/error.html
+++ b/desktop/screens/error.html
@@ -5,12 +5,23 @@
   button { font-size: 15px; padding: 8px 20px; border-radius: 6px; border: 1px solid #4a7dff;
            background: #4a7dff; color: white; cursor: pointer; }
 </style>
-<h2>The engines failed to start</h2>
+<h2 id="title"></h2>
 <pre id="message"></pre>
-<p>Logs: <code id="logDir"></code></p>
+<p id="logs">Logs: <code id="logDir"></code></p>
 <button onclick="window.persodubShell.retry()">Try again</button>
 <script>
   const q = new URLSearchParams(location.search);
+  // Each failure names itself. One fixed heading meant a preflight that
+  // stopped before anything started still announced that the engines had
+  // failed to start, which contradicted the sentence right below it.
+  const heading = q.get("title") || "The engines failed to start";
+  document.getElementById("title").textContent = heading;
+  document.title = `PersoDub: ${heading}`;  // the window title, which said
+                                            // "Startup failed" either way
   document.getElementById("message").textContent = q.get("message") || "(no details)";
-  document.getElementById("logDir").textContent = q.get("logDir") || "(unknown)";
+  // A preflight has no log to point at -- it stopped before a byte was written.
+  // An empty path under "Logs:" reads like something went missing.
+  const dir = q.get("logDir");
+  if (dir) document.getElementById("logDir").textContent = dir;
+  else document.getElementById("logs").remove();
 </script>

--- a/desktop/src/analytics.js
+++ b/desktop/src/analytics.js
@@ -13,9 +13,17 @@ const FAILURE_EVENTS = new Set(["dub_failure", "install_failure"]);
 // The published list. An error code that is not on it becomes "unknown" rather
 // than travelling verbatim -- that is what keeps a stray path or message, which
 // is what real error text is full of, out of the request.
+// The install steps, in order, exactly as installSpec.js names them. Kept here
+// rather than imported so a rename there cannot quietly start sending a value
+// the table has never heard of.
+export const INSTALL_STEPS = new Set([
+  "payload", "python", "venv-app", "venv-engines", "ffmpeg", "venv-qwen",
+  "models", "gemma", "nonverbal-weights", "kit-env",
+]);
+
 export const ERROR_CODES = new Set([
   "path-too-long", "disk-full", "network", "permission", "engine-start",
-  "out-of-memory", "unsupported-format", "engine-crash",
+  "out-of-memory", "unsupported-format", "engine-crash", "step-failed",
   "unknown",
 ]);
 
@@ -49,10 +57,16 @@ export function shouldReport({ event, lastDay, today }) {
 }
 
 /** The whole message. A field not named here cannot leave. */
-export function buildPayload({ event, os, version, device, errorCode }) {
+export function buildPayload({ event, os, version, device, errorCode, step }) {
   const payload = { event, os, version, device };
   if (FAILURE_EVENTS.has(event)) {
     payload.error_code = ERROR_CODES.has(errorCode) ? errorCode : "unknown";
+  }
+  // Which of the ten steps died. Only install failures have one, and only a
+  // published id travels -- the same rule as error codes, for the same reason.
+  // A failure before any step has run (a path or space preflight) carries none.
+  if (event === "install_failure" && step !== undefined) {
+    payload.step = INSTALL_STEPS.has(step) ? step : "unknown";
   }
   return payload;
 }
@@ -127,7 +141,7 @@ export function saveState(file, { device, lastDay = null }) {
  * not. It never throws: a count must never be able to break a launch or a dub.
  */
 export async function countEvent(event, {
-  mode, stateFile, url, os, version, errorCode,
+  mode, stateFile, url, os, version, errorCode, step,
   today = new Date().toISOString().slice(0, 10),
   timeoutMs, fetchImpl, log = console.log,
 }) {
@@ -138,7 +152,7 @@ export async function countEvent(event, {
   const state = loadState(stateFile);
   if (!shouldReport({ event, lastDay: state.lastDay, today })) return false;
 
-  const payload = buildPayload({ event, os, version, device: state.device, errorCode });
+  const payload = buildPayload({ event, os, version, device: state.device, errorCode, step });
 
   if (mode === "debug") {
     log(`[persodub-analytics] would send: ${JSON.stringify(payload)}`);
@@ -172,11 +186,19 @@ const ERROR_PATTERNS = [
   [/did not become ready|exit \d+/i,                 "engine-crash"],
 ];
 
-/** One published word for a whole error message. Never the message itself. */
-export function classifyError(message) {
+/** One published word for a whole error message. Never the message itself.
+ *
+ * `install` splits the catch-all in two. "engine-crash" was written for a
+ * running engine dying mid-dub, but its pattern (a nonzero exit) also matches
+ * every pip install and model download that fails during setup -- so install
+ * failures arrived claiming an engine had crashed when none had started yet.
+ */
+export function classifyError(message, { install = false } = {}) {
   if (typeof message !== "string" || message === "") return "unknown";
   for (const [pattern, code] of ERROR_PATTERNS) {
-    if (pattern.test(message)) return code;
+    if (pattern.test(message)) {
+      return install && code === "engine-crash" ? "step-failed" : code;
+    }
   }
   return "unknown";
 }

--- a/desktop/src/analytics.test.mjs
+++ b/desktop/src/analytics.test.mjs
@@ -89,6 +89,66 @@ test("a listed error code leaves as itself", () => {
   assert.equal(p.error_code, "path-too-long");
 });
 
+test("an install step that merely exited nonzero is not called an engine crash", () => {
+  // "engine-crash" means a running engine died, which is a dub-time event. A
+  // pip install or an hf download that exits 1 is not that -- and calling it
+  // that is what made the first four real install failures unreadable.
+  assert.equal(classifyError("Command failed: pip install ... exit 1", { install: true }), "step-failed");
+});
+
+test("a dub-time engine death keeps the name it was made for", () => {
+  assert.equal(classifyError("worker exit 1"), "engine-crash");
+  assert.equal(classifyError("sidecar did not become ready"), "engine-crash");
+});
+
+test("every other cause reads the same during an install", () => {
+  // Only the catch-all changes. A real disk-full or permission error is
+  // already named correctly and must not be relabelled.
+  for (const [msg, code] of [["ENOSPC", "disk-full"], ["EACCES", "permission"],
+                             ["ETIMEDOUT", "network"], ["ENOMEM", "out-of-memory"]]) {
+    assert.equal(classifyError(msg, { install: true }), code, msg);
+  }
+});
+
+test("step-failed is on the published list and travels as itself", () => {
+  const p = buildPayload({
+    event: "install_failure", os: "windows", version: "0.3.6", device: "a".repeat(32),
+    errorCode: "step-failed", step: "models",
+  });
+  assert.equal(p.error_code, "step-failed");
+});
+
+test("an install failure records which step it died in", () => {
+  // "engine-crash" on its own means "somewhere in ten steps" -- four real
+  // failures arrived that way and none of them could be acted on. The step is
+  // what turns a count into something fixable.
+  const p = buildPayload({
+    event: "install_failure", os: "windows", version: "0.3.5", device: "a".repeat(32),
+    errorCode: "disk-full", step: "gemma",
+  });
+  assert.equal(p.step, "gemma");
+});
+
+test("an unlisted step leaves as unknown", () => {
+  // Same rule as error codes: only the published list travels, so a path or a
+  // message can never reach the table through this field.
+  const p = buildPayload({
+    event: "install_failure", os: "mac", version: "0.3.5", device: "a".repeat(32),
+    errorCode: "disk-full", step: "C:\\Users\\someone\\video.mp4",
+  });
+  assert.equal(p.step, "unknown");
+});
+
+test("only install failures carry a step", () => {
+  for (const event of ["app_launch", "dub_success", "dub_failure"]) {
+    const p = buildPayload({
+      event, os: "mac", version: "0.3.5", device: "a".repeat(32),
+      errorCode: "out-of-memory", step: "gemma",
+    });
+    assert.equal(p.step, undefined, event);
+  }
+});
+
 test("a success carries no error code and no extra fields", () => {
   const p = buildPayload({
     event: "dub_success", os: "mac", version: "0.3.2", device: "a".repeat(32),
@@ -374,3 +434,14 @@ test("an install that finished but whose engines never started is its own code",
   assert.equal(p.error_code, "engine-start");
 });
 
+
+test("the failing step travels all the way to the wire", async () => {
+  const { sent, fetchImpl } = recorder();
+  await countEvent("install_failure", {
+    ...BASE, mode: "on", stateFile: tempStateFile(), fetchImpl,
+    errorCode: "disk-full", step: "gemma",
+  });
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].step, "gemma");
+  assert.equal(sent[0].error_code, "disk-full");
+});

--- a/desktop/src/config.js
+++ b/desktop/src/config.js
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync } from "node:fs";
+import { statfs } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
@@ -52,6 +53,49 @@ export function kitPathTooLong(kitDir, platform = process.platform) {
     + `Windows cannot open files deeper than ${WINDOWS_PATH_LIMIT} characters, and the kit `
     + `needs about ${KIT_DEEPEST_RELATIVE} more than the folder you pick. `
     + `Choose somewhere shorter, such as C:\\PersoDub.`;
+}
+
+const GB = 1024 ** 3;
+const gb = (bytes) => (bytes / GB).toFixed(1);
+
+/** A sentence to show the user, or null when there is room.
+ *
+ * Counted against what is still MISSING, not the whole kit: a machine that
+ * downloaded 15 GB and ran out at the end needs the remainder, and demanding
+ * the full size again would lock out the very people this exists to help.
+ */
+export function notEnoughSpace(neededBytes, freeBytes) {
+  // A null reading means the check could not run -- see freeSpaceAt.
+  if (freeBytes === null || freeBytes >= neededBytes) return null;
+  // No "not enough space" sentence here: the screen's heading says that, and
+  // repeating it pushed the two figures -- the only part that tells you what
+  // to do -- further down.
+  return `  Needs:  ${gb(neededBytes)} GB\n`
+    + `  Free:   ${gb(freeBytes)} GB\n\n`
+    // Both numbers, not just "not enough space": without them the usual
+    // outcome is clearing a little, retrying, and failing again.
+    + `Free up about ${gb(neededBytes - freeBytes)} GB and start again.`;
+}
+
+/** Bytes free on the volume the kit will live on, or null if unreadable.
+ *
+ * Walks up to the nearest folder that exists: on a first install the kit
+ * directory has not been created yet, and asking about it directly throws.
+ * Returning null rather than throwing is deliberate -- a preflight that cannot
+ * read the disk must not become the reason someone cannot install.
+ */
+export async function freeSpaceAt(dir, statfsImpl = statfs) {
+  let at = dir;
+  for (;;) {
+    try {
+      const fs = await statfsImpl(at);
+      return fs.bavail * fs.bsize;
+    } catch {
+      const up = dirname(at);
+      if (up === at) return null;  // reached the root without an answer
+      at = up;
+    }
+  }
 }
 
 export const DEFAULTS = {

--- a/desktop/src/config.test.mjs
+++ b/desktop/src/config.test.mjs
@@ -3,7 +3,9 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadConfig, DEFAULTS, defaultKitDir, kitPathTooLong, KIT_DEEPEST_RELATIVE, WINDOWS_PATH_LIMIT } from "./config.js";
+import { loadConfig, DEFAULTS, defaultKitDir, kitPathTooLong, notEnoughSpace, freeSpaceAt, KIT_DEEPEST_RELATIVE, WINDOWS_PATH_LIMIT } from "./config.js";
+
+const GB = 1024 ** 3;
 
 // --- where the kit goes when nothing overrides it -------------------------
 
@@ -78,6 +80,32 @@ test("the preflight only applies to Windows", () => {
   assert.equal(kitPathTooLong("/" + "x".repeat(room), "darwin"), null);
 });
 
+// --- free-space preflight -------------------------------------------------
+
+test("an install with less room than it needs is stopped before the first byte", () => {
+  // Reported by five machines: the install starts, downloads several
+  // gigabytes, and dies as a disk-full deep inside a step. Nothing checked
+  // first -- the "about 19 GB" on the installing screen was a sentence, not a
+  // test.
+  const msg = notEnoughSpace(19 * GB, 4 * GB);
+  assert.ok(msg, "expected a message");
+  assert.match(msg, /19\.0 GB/, msg); // what it needs
+  assert.match(msg, /4\.0 GB/, msg);  // what is there
+  assert.match(msg, /15\.0 GB/, msg); // how much more to free
+});
+
+test("an install that fits passes the preflight", () => {
+  assert.equal(notEnoughSpace(19 * GB, 25 * GB), null);
+});
+
+test("free space is only counted against what is still missing", () => {
+  // A machine that already downloaded most of the kit and ran out at the end
+  // needs the remainder, not the whole thing again. Demanding the full size
+  // would lock out exactly the people this check exists to help -- one of the
+  // five tried five times.
+  assert.equal(notEnoughSpace(2 * GB, 4 * GB), null);
+});
+
 test("defaults apply when no config file exists", () => {
   const cfg = loadConfig({ configPath: "/nonexistent/config.json", env: {} });
   assert.equal(cfg.sidecarPort, 3901);
@@ -106,4 +134,21 @@ test("empty kitDir in config file is ignored", () => {
   const p = join(dir, "config.json");
   writeFileSync(p, JSON.stringify({ kitDir: "" }));
   assert.equal(loadConfig({ configPath: p, env: {} }).kitDir, DEFAULTS.kitDir);
+});
+
+test("free space is read from the nearest folder that exists", async () => {
+  // The kit directory does not exist yet on a first install -- asking the
+  // filesystem about it directly throws, so the check has to walk up.
+  const missing = join(tmpdir(), "odspace-does-not-exist", "kit", "deeper");
+  const free = await freeSpaceAt(missing);
+  assert.equal(typeof free, "number");
+  assert.ok(free > 0, `expected a real figure, got ${free}`);
+});
+
+test("a filesystem that will not answer never blocks the install", async () => {
+  // Fail open. A preflight that cannot read the disk must not be the reason
+  // someone cannot install -- it exists to explain a failure, not to cause one.
+  const free = await freeSpaceAt("/anywhere", async () => { throw new Error("nope"); });
+  assert.equal(free, null);
+  assert.equal(notEnoughSpace(19 * GB, null), null);
 });

--- a/desktop/src/downloadPath.js
+++ b/desktop/src/downloadPath.js
@@ -1,0 +1,18 @@
+// Naming a finished download when something with that name is already there.
+//
+// Free of fs and electron so the node:test unit tests run with nothing else
+// present -- the caller passes `exists` (see desktop/main.js).
+export const MAX_COUNTER = 999;
+
+export function uniqueName(filename, exists) {
+  if (!exists(filename)) return filename;
+  const dot = filename.lastIndexOf(".");
+  const stem = dot > 0 ? filename.slice(0, dot) : filename;
+  const ext = dot > 0 ? filename.slice(dot) : "";
+  for (let n = 1; n <= MAX_COUNTER; n++) {
+    const candidate = `${stem}_${String(n).padStart(3, "0")}${ext}`;
+    if (!exists(candidate)) return candidate;
+  }
+  // 999 copies of one file means something is wrong; let Electron name it.
+  return null;
+}

--- a/desktop/src/downloadPath.test.mjs
+++ b/desktop/src/downloadPath.test.mjs
@@ -1,0 +1,31 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { uniqueName } from "./downloadPath.js";
+
+test("leaves the first download alone", () => {
+  assert.equal(uniqueName("dub_en.mp4", () => false), "dub_en.mp4");
+});
+
+test("counts up from 001 when the name is taken", () => {
+  const taken = new Set(["dub_en.mp4"]);
+  assert.equal(uniqueName("dub_en.mp4", (n) => taken.has(n)), "dub_en_001.mp4");
+});
+
+test("skips over numbers already used", () => {
+  const taken = new Set(["dub_en.mp4", "dub_en_001.mp4", "dub_en_002.mp4"]);
+  assert.equal(uniqueName("dub_en.mp4", (n) => taken.has(n)), "dub_en_003.mp4");
+});
+
+test("numbers a name that has no extension", () => {
+  const taken = new Set(["org"]);
+  assert.equal(uniqueName("org", (n) => taken.has(n)), "org_001");
+});
+
+test("keeps a dotfile whole rather than treating it as an extension", () => {
+  const taken = new Set([".srt"]);
+  assert.equal(uniqueName(".srt", (n) => taken.has(n)), ".srt_001");
+});
+
+test("gives up after three digits so Electron can name it", () => {
+  assert.equal(uniqueName("dub_en.mp4", () => true), null);
+});

--- a/desktop/src/installSpec.js
+++ b/desktop/src/installSpec.js
@@ -182,6 +182,28 @@ function withMissingKitEnvKeys(text) {
   return text + sep + missing.flatMap((a) => [a.comment, a.line]).join("\n") + "\n";
 }
 
+const GB = 1024 ** 3;
+
+// What each step leaves on disk, so the free-space preflight can add up the
+// steps that have not run yet. Measured 2026-08-24 on a finished mac install
+// (18.4 GB total, matching the "about 19 GB" the installing screen promises).
+//
+// Windows is larger and is NOT measured: torch there comes from the CUDA index
+// (see torchCuda below) and lands in both venvs, where macOS gets the much
+// smaller MPS wheel. The two venv figures below are the wheel sizes, not a
+// reading off a real machine -- worth re-measuring once a Windows kit is at
+// hand, since six of the eight install failures so far were Windows.
+const VENV_TORCH = IS_WIN ? 3.5 * GB : 1.5 * GB;
+
+/** How much room the steps that have not run yet still need. */
+export async function bytesStillNeeded(steps) {
+  let total = 0;
+  for (const s of steps) {
+    if (!(await s.isDone())) total += s.bytes;
+  }
+  return total;
+}
+
 export function buildSteps(ctx) {
   const k = (...p) => join(ctx.kitDir, ...p);
   const modelDone = (m) => m.markers.every((rel) => existsSync(k(...rel)));
@@ -202,9 +224,10 @@ export function buildSteps(ctx) {
     writeFileSync(okPath(id), "");
   };
 
-  const venvStep = (id, title, venvName, pipInstalls) => ({
+  const venvStep = (id, title, bytes, venvName, pipInstalls) => ({
     id,
     title,
+    bytes,
     isDone: () => existsSync(okPath(id)),
     run: async (report) => {
       const venvDir = k(venvName);
@@ -228,6 +251,7 @@ export function buildSteps(ctx) {
     {
       id: "payload",
       title: "Copying bundled files",
+      bytes: 0.3 * GB,
       // Done only when the kit's KIT_VERSION matches the app's own bundled
       // payload -- so an app update always re-copies app code + KIT_VERSION,
       // instead of a stale .ok marker skipping this step forever (venv/model
@@ -262,6 +286,7 @@ export function buildSteps(ctx) {
     {
       id: "python",
       title: "Downloading Python runtime (~50 MB)",
+      bytes: 0.2 * GB,
       isDone: () => existsSync(okPath("python")),
       run: async (report) => {
         mkdirSync(k("downloads"), { recursive: true });
@@ -275,8 +300,8 @@ export function buildSteps(ctx) {
         markOk("python");
       },
     },
-    venvStep("venv-app", "Installing app environment", "app_venv", [["-r", k("app", "requirements.txt")]]),
-    venvStep("venv-engines", "Installing AI engines (~3 GB)", "engines_venv", [
+    venvStep("venv-app", "Installing app environment", 0.2 * GB, "app_venv", [["-r", k("app", "requirements.txt")]]),
+    venvStep("venv-engines", "Installing AI engines (~3 GB)", VENV_TORCH, "engines_venv", [
       ...torchCuda,
       ["-r", k(reqEngines)],
       ["static-ffmpeg"],
@@ -284,6 +309,7 @@ export function buildSteps(ctx) {
     {
       id: "ffmpeg",
       title: "Setting up ffmpeg",
+      bytes: 0.2 * GB,
       isDone: () => existsSync(k("bin", exeName("ffmpeg"))) && existsSync(k("bin", exeName("ffprobe"))),
       run: async (report) => {
         report(null, "Fetching ffmpeg binaries");
@@ -309,7 +335,7 @@ export function buildSteps(ctx) {
         }
       },
     },
-    venvStep("venv-qwen", "Installing voice engine", "qwen_venv", [
+    venvStep("venv-qwen", "Installing voice engine", VENV_TORCH, "qwen_venv", [
       ...torchCuda,
       ["-r", k(reqQwen)],
       // The hf CLI (used by the models step) landed in 0.34, but transformers
@@ -319,6 +345,7 @@ export function buildSteps(ctx) {
     {
       id: "models",
       title: "Downloading AI models (~7 GB)",
+      bytes: 7.3 * GB,
       isDone: () => MODELS.every(modelDone),
       run: async (report) => {
         const hf = venvBin(k("qwen_venv"), "hf");
@@ -335,6 +362,7 @@ export function buildSteps(ctx) {
     {
       id: "gemma",
       title: "Downloading translation model Gemma (~8 GB)",
+      bytes: 8.1 * GB,
       // Both artifacts this step produces: engineCheck requires the ollama
       // binary too, so a manifest-only check marked a boot-failing install
       // "done" and never repaired it.
@@ -366,6 +394,7 @@ export function buildSteps(ctx) {
       // fails the install loudly instead, same as any other step here.
       id: "nonverbal-weights",
       title: "Downloading nonverbal-detection model (~140 MB)",
+      bytes: 0.2 * GB,
       isDone: () => existsSync(whisperCachePath()),
       run: async (report) => {
         report(null, "Downloading nonverbal-detection model");
@@ -375,6 +404,7 @@ export function buildSteps(ctx) {
     {
       id: "kit-env",
       title: "Writing configuration",
+      bytes: 0,
       // Must also check the managed additions, not just the original sniff
       // key -- otherwise a kit installed before they existed would satisfy
       // this forever and never receive them (see run, below).

--- a/desktop/src/installSpec.test.mjs
+++ b/desktop/src/installSpec.test.mjs
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   buildSteps, writeKitEnv, PYTHON_URL, PYTHON_SHA256, CAMPPLUS_SHA256,
-  OLLAMA_TGZ_SHA256, GEMMA_MODEL, GEMMA_MANIFEST,
+  OLLAMA_TGZ_SHA256, GEMMA_MODEL, GEMMA_MANIFEST, bytesStillNeeded,
 } from "./installSpec.js";
 import { IS_WIN, venvBin, exeName, TTS_DEVICE } from "./platform.js";
 
@@ -416,4 +416,38 @@ test("writeKitEnv includes the leakage-gate and worker-timeout additions", () =>
   assert.ok(s.includes("PERSODUB_SCORER_ASR_TIMEOUT=60"));
   assert.ok(s.includes("PERSODUB_TTS_TIMEOUT=900"));
   assert.ok(s.includes("PERSODUB_DIAR_TIMEOUT=1800"));
+});
+
+// --- how much room the remaining steps need -------------------------------
+
+test("every step declares how much room it takes", () => {
+  // The free-space preflight sums these. A step with no figure would silently
+  // count as free and let an install start that cannot finish.
+  for (const s of buildSteps(freshCtx())) {
+    assert.equal(typeof s.bytes, "number", `${s.id} has no bytes`);
+    assert.ok(s.bytes >= 0, `${s.id} is negative`);
+  }
+});
+
+test("the whole kit adds up to roughly what the installing screen promises", () => {
+  // Measured 2026-08-24 on a real mac install: 18.4 GB. The screen says
+  // "about 19 GB". If this drifts, one of the two is now lying to the user.
+  const total = buildSteps(freshCtx()).reduce((n, s) => n + s.bytes, 0) / 1024 ** 3;
+  assert.ok(total > 15 && total < 30, `total is ${total.toFixed(1)} GB`);
+});
+
+test("only the steps still missing are counted", async () => {
+  // The whole point: a machine that already has most of the kit needs the
+  // remainder, not the full download again.
+  const steps = [
+    { id: "a", bytes: 5, isDone: () => true },
+    { id: "b", bytes: 7, isDone: () => false },
+    { id: "c", bytes: 11, isDone: async () => false },
+  ];
+  assert.equal(await bytesStillNeeded(steps), 18);
+});
+
+test("nothing is needed once every step is done", async () => {
+  const steps = [{ id: "a", bytes: 5, isDone: () => true }];
+  assert.equal(await bytesStillNeeded(steps), 0);
 });

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ google-auth
 python-multipart
 pytest
 yt-dlp
+mcp

--- a/static/index.html
+++ b/static/index.html
@@ -1588,9 +1588,9 @@ async function renderExport(job) {
         <video controls src="${url}"></video>
         ${langLine}
         <div class="result-actions">
-          <a class="btn btn-primary" href="${url}" download="dubbed_${target}.mp4">Download dubbed video</a>
-          <a class="btn btn-secondary" href="/api/dub/result/${job.id}/original" download="original.mp4">Download original</a>
-          ${srtText ? `<a class="btn btn-secondary" href="/api/dub/result/${job.id}/srt?download=1" download="dubbed_${target}.srt">Download subtitles (.srt)</a>` : ""}
+          <a class="btn btn-primary" href="${url}" download="dub_${target}.mp4">Download dubbed video</a>
+          ${job.from_link ? `<a class="btn btn-secondary" href="/api/dub/result/${job.id}/original" download="org.mp4">Download original</a>` : ""}
+          ${srtText ? `<a class="btn btn-secondary" href="/api/dub/result/${job.id}/srt?download=1" download="dub_${target}.srt">Download subtitles (.srt)</a>` : ""}
         </div>
       </div>
       <div class="srt-list">${srtRows}</div>

--- a/static/index.html
+++ b/static/index.html
@@ -1629,7 +1629,11 @@ async function renderExport(job) {
   const target = job.language_code || "out";
   const srtText = await fetchResultSrt(job.id).catch(() => null);
   const srtRows = srtText
-    ? parseSrt(srtText).map((c) => `<div class="srt-row"><span class="srt-time">${c.start}–${c.end}</span><span class="srt-text">${escapeHtml(c.text)}</span></div>`).join("")
+    // Escape the timecodes too, not just the text. The .srt served back is the
+    // file the user handed us, verbatim -- parseSrt takes whatever sits before
+    // "-->" as the start time without checking it is a timecode, so a crafted
+    // subtitle put markup straight into innerHTML here.
+    ? parseSrt(srtText).map((c) => `<div class="srt-row"><span class="srt-time">${escapeHtml(c.start)}–${escapeHtml(c.end)}</span><span class="srt-text">${escapeHtml(c.text)}</span></div>`).join("")
     : '<div class="srt-empty">No subtitle file was recorded for this job.</div>';
 
   // The four things a finished job can hand back: original + dub, and the two

--- a/static/index.html
+++ b/static/index.html
@@ -1454,6 +1454,10 @@ function readOptions() {
     qualityMode: $("qualitySelect").value,
     numSpeakers: $("numSpeakers").value ? Number($("numSpeakers").value) : undefined,
     translateEngine: $("translateSelect").value,
+    // A link's title is only known here -- the probe already fetched it, while
+    // the server learns nothing from downloading the video. Names the job's
+    // folder, so send it along with the job.
+    project: state.source === "link" ? (state.linkProbe || {}).title : undefined,
   };
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -146,6 +146,15 @@
   .job-dot.error { background: var(--destructive); }
   .job-dot.cancelled { background: var(--muted-foreground); }
   .job-row .job-info { min-width: 0; }
+  /* The row itself is a <button>, so the delete control sits beside it rather
+     than inside. It stays hidden until the row is hovered or it has focus --
+     an always-visible delete next to every job invites the wrong click. */
+  .job-line { display: flex; align-items: center; }
+  .job-line .job-row { flex: 1; min-width: 0; }
+  .job-del { border: none; background: none; cursor: pointer; padding: 6px 10px; color: var(--muted-foreground); font: inherit; font-size: 0.78rem; opacity: 0; flex-shrink: 0; }
+  .job-line:hover .job-del, .job-del:focus-visible { opacity: 1; }
+  .job-del:hover { color: var(--destructive); }
+  .job-del.confirming { opacity: 1; color: var(--destructive); font-weight: 700; }
   .job-name { font-size: 0.8rem; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .job-meta { font-size: 0.7rem; color: var(--muted-foreground); }
 
@@ -1386,6 +1395,17 @@ function upsertHistory(entry) {
   renderHistory();
 }
 
+function removeHistory(jobId) {
+  saveHistory(loadHistory().filter((j) => j.jobId !== jobId));
+  // The open Export tab would be showing files that are gone now.
+  if (state.jobId === jobId) {
+    state.jobId = null;
+    state.pollGeneration += 1;
+    switchTab("upload");
+  }
+  renderHistory();
+}
+
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 }
@@ -1409,7 +1429,45 @@ function renderHistory() {
     row.innerHTML = `<span class="job-dot ${dotClass}"></span>
       <div class="job-info"><div class="job-name">${escapeHtml(entry.fileName)}</div><div class="job-meta">${escapeHtml(entry.metaText || "")}</div></div>`;
     row.addEventListener("click", () => resumeJob(entry.jobId));
-    container.appendChild(row);
+
+    // Deleting a job's folder cannot be undone, so the button asks once by
+    // turning into "Sure?" -- not window.confirm(), which freezes every event
+    // in the Electron shell until it is dismissed.
+    const del = document.createElement("button");
+    del.className = "job-del";
+    del.type = "button";
+    del.title = "Delete this job's files";
+    del.textContent = "Delete";
+    del.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      if (!del.classList.contains("confirming")) {
+        del.classList.add("confirming");
+        del.textContent = "Sure?";
+        setTimeout(() => {
+          del.classList.remove("confirming");
+          del.textContent = "Delete";
+        }, 4000);
+        return;
+      }
+      del.disabled = true;
+      del.textContent = "Deleting…";
+      try {
+        const r = await fetch(`/api/dub/jobs/${entry.jobId}/workspace`, { method: "DELETE" });
+        if (!r.ok) throw new Error((await r.json()).detail || "Could not delete this job");
+        removeHistory(entry.jobId);
+      } catch (err) {
+        del.disabled = false;
+        del.classList.remove("confirming");
+        del.textContent = "Delete";
+        del.title = err.message;
+      }
+    });
+
+    const line = document.createElement("div");
+    line.className = "job-line";
+    line.appendChild(row);
+    line.appendChild(del);
+    container.appendChild(line);
   }
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -1564,6 +1564,9 @@ function langName(code) {
 // ---------------- Export tab ----------------
 async function renderExport(job) {
   const el = $("exportContent");
+  // Tell the shell where this job's downloads belong. It has to be handed over
+  // before any button is clicked, because will-download cannot ask for it.
+  window.persodubShell?.rememberJob?.({ id: job.id, project: job.project, day: job.day });
   const url = resultUrl(job.id);
   const target = job.language_code || "out";
   const srtText = await fetchResultSrt(job.id).catch(() => null);

--- a/tests/test_auto_translate.py
+++ b/tests/test_auto_translate.py
@@ -217,6 +217,30 @@ def test_line_still_in_the_wrong_language_after_two_rounds_is_kept_and_warned(tm
     assert any("1 lines still not in the target language" in m for m in logs)
 
 
+def test_original_srt_is_written_before_translation_overwrites(tmp_path):
+    # app/pipeline.py:232 -- `c["text"] = tr` overwrites the source text in place, so the
+    # source is gone the moment translation lands. app/dub_script.py needs it to show a
+    # line's source next to its translation, so it is written out first.
+    # The name is original.srt, not source.srt: source.srt already belongs to a
+    # caller-uploaded source script (app/main.py:388).
+    src = [
+        {"start": 0.0, "end": 2.0, "text": "Hello there, nice to meet you."},
+        {"start": 3.0, "end": 5.0, "text": "The weather is lovely today."},
+    ]
+    eng = UnparseableTranslator(
+        translate_responses=[["안녕하세요 반갑습니다", "오늘 날씨가 좋네요"]]
+    )
+
+    pipeline._auto_translate_srt(src, "ko", eng, str(tmp_path), source_lang="en")
+
+    original = tmp_path / "original.srt"
+    assert original.exists(), "original.srt was not written"
+    assert [c["text"] for c in read_cues(str(original))] == [
+        "Hello there, nice to meet you.",
+        "The weather is lovely today.",
+    ]
+    assert (tmp_path / "translated.srt").exists()  # the existing output is untouched
+
 # --- _carry_speaker_labels -------------------------------------------------------
 
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Dropping a finished job's intermediate audio. Files only, no pipeline run."""
+from app.pipeline import cleanup_intermediates
+
+KEEP = ["dubbed.mp4", "input.mp4", "original.srt", "translated.srt",
+        "edited.srt", "sub.srt", "nonverbal_manifest.json"]
+DROP = ["vocals.wav", "background.wav", "qwen_dub_48k.wav",
+        "qwen_line_0.wav", "qwen_line_12.wav", "qwen_ref_Barack_Obama.wav"]
+
+
+def _populate(tmp_path):
+    for name in KEEP + DROP:
+        (tmp_path / name).write_bytes(b"x")
+
+
+def test_drops_intermediate_audio_and_keeps_the_results(tmp_path):
+    _populate(tmp_path)
+
+    removed = cleanup_intermediates(str(tmp_path))
+
+    assert removed == len(DROP)
+    for name in KEEP:
+        assert (tmp_path / name).exists(), "%s should have been kept" % name
+    for name in DROP:
+        assert not (tmp_path / name).exists(), "%s should have been dropped" % name
+
+
+def test_is_safe_to_run_twice(tmp_path):
+    _populate(tmp_path)
+    cleanup_intermediates(str(tmp_path))
+    assert cleanup_intermediates(str(tmp_path)) == 0
+
+
+def test_survives_a_folder_that_is_not_there(tmp_path):
+    assert cleanup_intermediates(str(tmp_path / "gone")) == 0
+
+
+def test_delete_workspace_removes_the_folder(tmp_path, monkeypatch):
+    from app import main
+
+    work = tmp_path / "job"
+    work.mkdir()
+    (work / "dubbed.mp4").write_bytes(b"vid")
+    monkeypatch.setattr(main, "WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(main.job_store, "get", lambda jid: {
+        "id": jid, "status": "done", "result": {"out_path": str(work / "dubbed.mp4")}})
+
+    assert main.dub_job_delete_workspace("abc")["deleted"] is True
+    assert not work.exists()
+
+
+def test_delete_workspace_refuses_a_path_outside_it(tmp_path, monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+    from app import main
+
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "dubbed.mp4").write_bytes(b"vid")
+    monkeypatch.setattr(main, "WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.setattr(main.job_store, "get", lambda jid: {
+        "id": jid, "status": "done", "result": {"out_path": str(outside / "dubbed.mp4")}})
+
+    with pytest.raises(HTTPException) as e:
+        main.dub_job_delete_workspace("abc")
+    assert e.value.status_code == 400
+    assert outside.exists()
+
+
+def test_delete_workspace_refuses_while_the_job_runs(monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+    from app import main
+
+    monkeypatch.setattr(main.job_store, "get", lambda jid: {"id": jid, "status": "running"})
+    with pytest.raises(HTTPException) as e:
+        main.dub_job_delete_workspace("abc")
+    assert e.value.status_code == 409

--- a/tests/test_dub_api.py
+++ b/tests/test_dub_api.py
@@ -501,3 +501,26 @@ def test_dub_start_source_language_hint_absent_is_none(monkeypatch):
             break
         time.sleep(0.02)
     assert captured["source_language_code"] is None
+
+
+def test_dub_start_rejects_a_language_code_that_is_not_one():
+    """language_code is pasted into the job's folder name (app/main.py _job_dir).
+    It reached the path unchecked while every sibling field was validated, so a
+    code carrying "../.." walked the job out of the workspace. Refuse it here,
+    the way stt_engine is refused, rather than quietly renaming it.
+    """
+    for hostile in ["../../../../tmp/PWNED", "..", "a/b", "a\\b", "ko ko", "k" * 17]:
+        r = client.post(
+            "/api/dub/start",
+            files={"video": ("v.mp4", b"vid", "video/mp4")},
+            data={"language": "Korean", "language_code": hostile},
+        )
+        assert r.status_code == 422, f"{hostile!r} was accepted"
+
+
+def test_dub_start_still_takes_the_language_codes_people_use():
+    # The guard must not turn away real codes -- BCP-47 tags carry hyphens.
+    from app.main import _valid_language_code
+
+    for good in ["ko", "en", "ja", "zh-CN", "pt_BR", "es-419"]:
+        assert _valid_language_code(good), good

--- a/tests/test_dub_script.py
+++ b/tests/test_dub_script.py
@@ -5,7 +5,9 @@ Pure logic over files only -- no container, no network, no TTS (docs/development
 """
 import pytest
 
-from app.dub_script import DUB_NAME, EDITED_NAME, ORIGINAL_NAME, load_lines, script_path
+from app.dub_script import (
+    DUB_NAME, EDITED_NAME, ORIGINAL_NAME, edit_line, export_srt, load_lines, script_path,
+)
 from app.text.srt import build_srt
 
 
@@ -79,3 +81,59 @@ def test_edited_file_wins_over_the_dubbed_one(tmp_path):
 def test_missing_script_raises_a_clear_error(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_lines(str(tmp_path), "ko")
+
+
+def test_edit_writes_to_edited_and_leaves_the_dub_alone(tmp_path):
+    # translated.srt is the record of what the dub actually read -- without it there is
+    # nothing to compare an edit against, so edits go to edited.srt instead.
+    write(tmp_path / ORIGINAL_NAME, [(0.0, 2.0, "Stay with me.")])
+    write(tmp_path / DUB_NAME, [(0.0, 2.0, "나와 함께 있어주세요 제발")])  # 2.50s, overshoots
+
+    line = edit_line(str(tmp_path), 1, "정신 차려요 지금 당장", "ko")  # 2.05s, inside [1.70, 2.30]
+
+    assert line["line"] == 1
+    assert line["text"] == "정신 차려요 지금 당장"
+    assert line["fits"] is True
+    assert (tmp_path / EDITED_NAME).exists()
+    assert "나와 함께 있어주세요 제발" in (tmp_path / DUB_NAME).read_text(encoding="utf-8")
+
+
+def test_second_edit_builds_on_the_first(tmp_path):
+    write(tmp_path / DUB_NAME, [(0.0, 2.0, "첫째 줄"), (2.0, 4.0, "둘째 줄")])
+
+    edit_line(str(tmp_path), 1, "고친 첫째", "ko")
+    edit_line(str(tmp_path), 2, "고친 둘째", "ko")
+
+    assert [ln["text"] for ln in load_lines(str(tmp_path), "ko")] == ["고친 첫째", "고친 둘째"]
+
+
+def test_edit_keeps_the_timing(tmp_path):
+    # Only the words change. Shifting a line's timing would pull the voice out of sync.
+    write(tmp_path / DUB_NAME, [(1.5, 3.25, "옛날 번역")])
+
+    line = edit_line(str(tmp_path), 1, "새 번역", "ko")
+
+    assert line["start"] == 1.5
+    assert line["end"] == 3.25
+
+
+def test_edit_rejects_a_line_number_out_of_range(tmp_path):
+    write(tmp_path / DUB_NAME, [(0.0, 2.0, "한 줄뿐")])
+
+    with pytest.raises(ValueError) as e:
+        edit_line(str(tmp_path), 7, "아무거나", "ko")
+    assert "7" in str(e.value)
+    assert "1" in str(e.value)  # says how many lines there actually are
+
+
+def test_export_writes_the_current_script(tmp_path):
+    write(tmp_path / DUB_NAME, [(0.0, 2.0, "옛날 번역")])
+    out = tmp_path / "exported.srt"
+
+    export_srt(str(tmp_path), str(out))
+    assert "옛날 번역" in out.read_text(encoding="utf-8")
+
+    edit_line(str(tmp_path), 1, "고친 번역", "ko")
+    export_srt(str(tmp_path), str(out))
+    assert "고친 번역" in out.read_text(encoding="utf-8")
+    assert "옛날 번역" not in out.read_text(encoding="utf-8")

--- a/tests/test_dub_script.py
+++ b/tests/test_dub_script.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Reading a job's script, pairing it with its source, and measuring line length.
+
+Pure logic over files only -- no container, no network, no TTS (docs/development.md).
+"""
+import pytest
+
+from app.dub_script import DUB_NAME, EDITED_NAME, ORIGINAL_NAME, load_lines, script_path
+from app.text.srt import build_srt
+
+
+def write(path, cues):
+    """Write (start, end, text) triples out as an SRT file."""
+    path.write_text(
+        build_srt([{"start": s, "end": e, "text": t} for s, e, t in cues]),
+        encoding="utf-8",
+    )
+
+
+def test_pairs_translation_with_source_by_time(tmp_path):
+    # Sentence splitting after translation (app/pipeline.py:235) can turn one source line
+    # into two translated ones, so line numbers no longer line up -- pairing by number
+    # would leave the second translation without a source. Pair by time instead.
+    write(tmp_path / ORIGINAL_NAME, [(0.0, 4.0, "You have no idea what you have done.")])
+    write(tmp_path / DUB_NAME, [(0.0, 2.0, "네가 무슨 짓을 했는지"), (2.0, 4.0, "넌 몰라")])
+
+    lines = load_lines(str(tmp_path), "ko")
+
+    assert [line["line"] for line in lines] == [1, 2]
+    # both halves point at the same source line
+    assert [line["source"] for line in lines] == [
+        "You have no idea what you have done.",
+        "You have no idea what you have done.",
+    ]
+
+
+def test_reports_slot_and_whether_it_fits(tmp_path):
+    # Korean is estimated at 4.4 syllables/sec, so a 2.0s slot fits roughly 7.5-10 chars.
+    write(tmp_path / ORIGINAL_NAME, [(0.0, 2.0, "Stay with me.")])
+    write(tmp_path / DUB_NAME, [(0.0, 2.0, "이건 도저히 이 시간 안에 다 읽을 수 없는 아주 긴 문장입니다")])
+
+    line = load_lines(str(tmp_path), "ko")[0]
+
+    assert line["slot"] == 2.0
+    assert line["estimated"] > 2.0
+    assert line["fits"] is False
+
+
+def test_short_line_also_does_not_fit(tmp_path):
+    # A line too short for its slot leaves dead silence, so it is "not fitting" too --
+    # app.text.length_fit.in_window is a window, not a ceiling.
+    write(tmp_path / ORIGINAL_NAME, [(0.0, 6.0, "A very long sentence indeed.")])
+    write(tmp_path / DUB_NAME, [(0.0, 6.0, "응")])
+
+    assert load_lines(str(tmp_path), "ko")[0]["fits"] is False
+
+
+def test_missing_original_leaves_source_empty(tmp_path):
+    # Jobs from before original.srt existed, and jobs given a ready-made translated SRT
+    # (app/main.py:315), never go through _auto_translate_srt -- still readable, no source.
+    write(tmp_path / DUB_NAME, [(0.0, 2.0, "네가 무슨 짓을 했는지 넌 몰라")])
+
+    lines = load_lines(str(tmp_path), "ko")
+
+    assert len(lines) == 1
+    assert lines[0]["source"] is None
+    assert lines[0]["text"] == "네가 무슨 짓을 했는지 넌 몰라"
+
+
+def test_edited_file_wins_over_the_dubbed_one(tmp_path):
+    # translated.srt is what the dub actually read; edits always land in edited.srt.
+    write(tmp_path / DUB_NAME, [(0.0, 2.0, "옛날 번역")])
+    write(tmp_path / EDITED_NAME, [(0.0, 2.0, "고친 번역")])
+
+    assert script_path(str(tmp_path)).endswith(EDITED_NAME)
+    assert load_lines(str(tmp_path), "ko")[0]["text"] == "고친 번역"
+
+
+def test_missing_script_raises_a_clear_error(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_lines(str(tmp_path), "ko")

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -85,3 +85,40 @@ def test_job_dir_falls_back_to_a_random_name(tmp_path, monkeypatch):
     assert main.os.path.isdir(made)
     assert "2026-08-21" in made
     assert main.os.path.basename(made) not in ("_en", "")
+
+
+def _finished_job(tmp_path, **extra):
+    """A job record shaped like a finished dub, with its files on disk."""
+    work = tmp_path / "job"
+    work.mkdir()
+    (work / "dubbed.mp4").write_bytes(b"vid")
+    (work / "input.mp4").write_bytes(b"src")
+    job = {"id": "abc123", "status": "done", "language_code": "en",
+           "result": {"out_path": str(work / "dubbed.mp4")}}
+    job.update(extra)
+    return job
+
+
+def test_download_names_are_short_and_say_the_language(tmp_path, monkeypatch):
+    from app import main
+
+    job = _finished_job(tmp_path, from_link=True)
+    monkeypatch.setattr(main.job_store, "get", lambda jid: job)
+
+    assert main.dub_result("abc123").filename == "dub_en.mp4"
+    assert main.dub_result_original("abc123").filename == "org.mp4"
+
+
+def test_original_is_refused_for_an_uploaded_file(tmp_path, monkeypatch):
+    # The user already has the file they uploaded; only a link job has an
+    # original they cannot otherwise get.
+    import pytest
+    from fastapi import HTTPException
+    from app import main
+
+    job = _finished_job(tmp_path, from_link=False)
+    monkeypatch.setattr(main.job_store, "get", lambda jid: job)
+
+    with pytest.raises(HTTPException) as e:
+        main.dub_result_original("abc123")
+    assert e.value.status_code == 404

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -54,3 +54,34 @@ def test_next_free_gives_up_after_three_digits():
     # the caller's random-name path rather than growing a fourth digit.
     taken = ["x"] + ["x_%03d" % i for i in range(1, 1000)]
     assert next_free("x", taken) is None
+
+
+def test_job_dir_uses_date_project_and_language(tmp_path, monkeypatch):
+    from app import main
+
+    monkeypatch.setattr(main, "WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(main, "_today", lambda: "2026-08-21")
+
+    first = main._job_dir("참교육1화", "en")
+    assert first.endswith("2026-08-21/참교육1화_en")
+    assert main.os.path.isdir(first)
+
+    # a second English run of the same title on the same day counts up
+    assert main._job_dir("참교육1화", "en").endswith("2026-08-21/참교육1화_en_001")
+
+    # a different language is a different folder, not a collision
+    assert main._job_dir("참교육1화", "ja").endswith("2026-08-21/참교육1화_ja")
+
+
+def test_job_dir_falls_back_to_a_random_name(tmp_path, monkeypatch):
+    # A title that survives sanitizing as "" must not fail the job -- the old
+    # random-name behaviour (app/main.py:374) is the safety net.
+    from app import main
+
+    monkeypatch.setattr(main, "WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(main, "_today", lambda: "2026-08-21")
+
+    made = main._job_dir("///", "en")
+    assert main.os.path.isdir(made)
+    assert "2026-08-21" in made
+    assert main.os.path.basename(made) not in ("_en", "")

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -122,3 +122,21 @@ def test_original_is_refused_for_an_uploaded_file(tmp_path, monkeypatch):
     with pytest.raises(HTTPException) as e:
         main.dub_result_original("abc123")
     assert e.value.status_code == 404
+
+
+def test_job_dir_cannot_be_walked_out_of_the_workspace(tmp_path, monkeypatch):
+    """The language half of the folder name is caller-supplied and was pasted
+    into the path unchecked, so "../../.." in it escaped the workspace and the
+    job then wrote input.mp4 over whatever lived there. The title half was
+    already run through safe_name; this is the half that was not.
+    """
+    from app import main
+
+    monkeypatch.setattr(main, "WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(main, "_today", lambda: "2026-08-21")
+
+    for hostile in ["../../../../tmp/PWNED", "..", "a/b", "a\\b", "ko\x00"]:
+        work = main._job_dir("myvideo", hostile)
+        real = main.os.path.realpath(work)
+        root = main.os.path.realpath(str(tmp_path))
+        assert real.startswith(root + main.os.sep), f"{hostile!r} escaped to {real}"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Turning a video's title into a folder name. Pure string work, no filesystem."""
+import unicodedata
+
+from app.text.naming import next_free, safe_name
+
+
+def test_keeps_a_plain_name_as_is():
+    assert safe_name("참교육1화") == "참교육1화"
+    assert safe_name("Breaking Bad S01E01") == "Breaking Bad S01E01"
+
+
+def test_normalizes_korean_to_nfc():
+    # macOS hands back decomposed Korean (NFD). Storing it that way makes the
+    # folder unfindable later by a name built the normal (NFC) way.
+    decomposed = unicodedata.normalize("NFD", "참교육")
+    assert decomposed != "참교육"  # the two really are different strings
+    assert safe_name(decomposed) == "참교육"
+
+
+def test_strips_characters_a_path_cannot_hold():
+    assert safe_name('a/b:c*d?e"f<g>h|i') == "abcdefghi"
+
+
+def test_trims_leading_and_trailing_junk():
+    assert safe_name("  . 참교육 . ") == "참교육"
+
+
+def test_truncates_a_very_long_name():
+    assert len(safe_name("가" * 300, max_len=80)) == 80
+
+
+def test_falls_back_to_empty_when_nothing_survives():
+    # The caller treats "" as "could not build a name" and uses a random one.
+    assert safe_name("///") == ""
+    assert safe_name("   ") == ""
+
+
+def test_next_free_returns_the_base_when_nothing_taken():
+    assert next_free("참교육1화_en", []) == "참교육1화_en"
+
+
+def test_next_free_counts_up_from_001():
+    assert next_free("참교육1화_en", ["참교육1화_en"]) == "참교육1화_en_001"
+
+
+def test_next_free_skips_over_what_is_already_there():
+    taken = ["참교육1화_en", "참교육1화_en_001", "참교육1화_en_002"]
+    assert next_free("참교육1화_en", taken) == "참교육1화_en_003"
+
+
+def test_next_free_gives_up_after_three_digits():
+    # 999 of the same name on one day means something is wrong; fall back to
+    # the caller's random-name path rather than growing a fourth digit.
+    taken = ["x"] + ["x_%03d" % i for i in range(1, 1000)]
+    assert next_free("x", taken) is None

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -62,15 +62,21 @@ def test_job_dir_uses_date_project_and_language(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "WORKSPACE", str(tmp_path))
     monkeypatch.setattr(main, "_today", lambda: "2026-08-21")
 
+    # Compared with os.path.join, not a literal "/": Windows builds the same
+    # folder with a backslash, and a hardcoded slash failed there while the
+    # code was correct.
+    def ends(path, *parts):
+        return path.endswith(main.os.path.join(*parts))
+
     first = main._job_dir("참교육1화", "en")
-    assert first.endswith("2026-08-21/참교육1화_en")
+    assert ends(first, "2026-08-21", "참교육1화_en")
     assert main.os.path.isdir(first)
 
     # a second English run of the same title on the same day counts up
-    assert main._job_dir("참교육1화", "en").endswith("2026-08-21/참교육1화_en_001")
+    assert ends(main._job_dir("참교육1화", "en"), "2026-08-21", "참교육1화_en_001")
 
     # a different language is a different folder, not a collision
-    assert main._job_dir("참교육1화", "ja").endswith("2026-08-21/참교육1화_ja")
+    assert ends(main._job_dir("참교육1화", "ja"), "2026-08-21", "참교육1화_ja")
 
 
 def test_job_dir_falls_back_to_a_random_name(tmp_path, monkeypatch):

--- a/tests/test_result_downloads.py
+++ b/tests/test_result_downloads.py
@@ -47,15 +47,27 @@ def test_dub_download_is_named_for_the_target_language(monkeypatch):
     jid = _finished_job(monkeypatch, target="ko")
     r = client.get(f"/api/dub/result/{jid}")
     assert r.status_code == 200
-    assert 'filename="dubbed_ko.mp4"' in r.headers["content-disposition"]
+    assert 'filename="dub_ko.mp4"' in r.headers["content-disposition"]
 
 
-def test_original_is_downloadable(monkeypatch):
+def test_original_is_downloadable_for_a_link_job(monkeypatch):
+    # _finished_job posts an uploaded file; stamping from_link makes the job
+    # look like one that pulled its video from a URL, which is the only case
+    # where the original is handed back.
+    from app.main import job_store
     jid = _finished_job(monkeypatch)
+    job_store._update(jid, from_link=True)
+
     r = client.get(f"/api/dub/result/{jid}/original")
     assert r.status_code == 200
     assert r.content == b"FAKEMP4"
-    assert 'filename="original.mp4"' in r.headers["content-disposition"]
+    assert 'filename="org.mp4"' in r.headers["content-disposition"]
+
+
+def test_original_is_refused_for_an_uploaded_file(monkeypatch):
+    # The user already has the file they uploaded -- handing it back is noise.
+    jid = _finished_job(monkeypatch)
+    assert client.get(f"/api/dub/result/{jid}/original").status_code == 404
 
 
 def test_original_404s_when_the_job_is_unknown():
@@ -66,7 +78,7 @@ def test_srt_download_has_a_filename(monkeypatch):
     jid = _finished_job(monkeypatch, target="ja")
     r = client.get(f"/api/dub/result/{jid}/srt?download=1")
     assert r.status_code == 200
-    assert 'filename="dubbed_ja.srt"' in r.headers["content-disposition"]
+    assert 'filename="dub_ja.srt"' in r.headers["content-disposition"]
 
 
 def test_srt_viewer_response_is_unchanged(monkeypatch):

--- a/ui/src/dubApi.mjs
+++ b/ui/src/dubApi.mjs
@@ -126,6 +126,11 @@ export function buildDubFormData(opts) {
   }
   if (opts.srt) fd.append("srt", opts.srt);
   if (opts.sourceSrt) fd.append("source_srt", opts.sourceSrt);
+  // Names the job's folder and the download folder. Sent from here because the
+  // screen already knows a link's title from its own probe, while the server
+  // only learns it after the download (app/source_fetch.py's fetch returns
+  // nothing). Omitted, the server falls back to the filename or the URL.
+  if (opts.project) fd.append("project", opts.project);
 
   return fd;
 }


### PR DESCRIPTION
Twelve commits that had been sitting unpushed since 2026-08-21, plus today's install work.

## Install

- **Free-space preflight.** The installing screen promised "about 19 GB" but nothing checked, so five machines downloaded gigabytes and died as a disk-full deep inside a step. The check counts only the steps still missing, so a half-done install asks for the remainder rather than the whole kit again.
- **Each failure names itself.** One fixed heading meant a preflight that stopped before anything started still announced that the engines had failed to start. A preflight also no longer points at a log directory it never wrote to.
- **Install failures record which of the ten steps they died in.** Four real failures arrived as `engine-crash` — "somewhere in ten steps" — and could not be acted on. `engine-crash` also stops being the catch-all for an install step that merely exited nonzero; that is now `step-failed`, leaving the old name to mean what it was written for.

## Job output

- Job folders are named by date, project and language; downloads are `dub_<lang>.mp4`.
- A finished job drops its intermediate audio, and a job's folder can be deleted from the app.

## Script tools

- A job's source script is kept before translation overwrites it, paired with its translation by time, and editable into a separate file — exposed over MCP. No screen changes.

## Security

- `language_code` reached the job's folder path unchecked while every sibling field was validated, so a code carrying `../..` walked the job out of the workspace and wrote `input.mp4` over whatever lived there. Refused at the API, and sanitized again where the name is built.
- Subtitle timecodes were interpolated into `innerHTML` unescaped. The `.srt` served back is the file the user handed us, verbatim, and `parseSrt` takes whatever sits before `-->` as the start time.

## Testing

672 Python tests, 165 desktop tests. Security review run over the full diff.