### PR TITLE
Stop console windows flashing behind the app on Windows

### DIFF
--- a/desktop/src/exec.js
+++ b/desktop/src/exec.js
@@ -8,7 +8,9 @@ const CONTROL_SEQUENCES = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 
 export function run(argv, { cwd, env, onLine = () => {} } = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(argv[0], argv.slice(1), { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+    // windowsHide: the installer runs console programs (tar, pip, hf...) from
+    // a GUI process, and without it each one opened its own console window.
+    const child = spawn(argv[0], argv.slice(1), { cwd, env, stdio: ["ignore", "pipe", "pipe"], windowsHide: true });
     const recent = [];
     const feed = (buf) => {
       // Split on \r as well as \n: a progress bar redraws its line with a bare

--- a/desktop/src/ollamaPull.js
+++ b/desktop/src/ollamaPull.js
@@ -9,7 +9,9 @@ import { getFreePort } from "./freePort.js";
 export async function pullOllamaModel({ bin, modelsDir, model, onLine = () => {} }) {
   const port = await getFreePort();
   const env = { ...process.env, OLLAMA_HOST: `127.0.0.1:${port}`, OLLAMA_MODELS: modelsDir };
-  const server = spawn(bin, ["serve"], { env, stdio: "ignore" });
+  // windowsHide keeps the temporary server from showing a console window for
+  // the whole duration of the pull.
+  const server = spawn(bin, ["serve"], { env, stdio: "ignore", windowsHide: true });
   try {
     await waitReady(bin, env);
     await run([bin, "pull", model], { env, onLine });

--- a/desktop/src/orchestrator.js
+++ b/desktop/src/orchestrator.js
@@ -14,7 +14,10 @@ const PIDS_FILE = "pids.json";
 function forceKillTree(pid) {
   if (!Number.isInteger(pid) || pid <= 1) return;
   if (IS_WIN) {
-    try { spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore" }); } catch { /* gone */ }
+    // windowsHide: taskkill is a console program launched from a GUI process,
+    // so without it every kill flashed a console window on screen -- three per
+    // launch (stale engines) and three more per quit.
+    try { spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true }); } catch { /* gone */ }
     return;
   }
   try { process.kill(-pid, "SIGKILL"); } catch { /* group gone */ }
@@ -51,10 +54,13 @@ function substitute(argv, port) {
 
 function launch(argv, { cwd, env, logPath }) {
   const fd = openSync(logPath, "a");
-  // windowsHide keeps detached children from flashing a console window; on
-  // Windows detached also makes the child a new process group so taskkill /T
-  // can later reap its whole tree.
-  return spawn(argv[0], argv.slice(1), { cwd, env, detached: true, windowsHide: true, stdio: ["ignore", fd, fd] });
+  // POSIX detaches so the engine leads a process group stopChild can signal.
+  // Windows must NOT detach: DETACHED_PROCESS strips the console entirely and
+  // makes Windows ignore windowsHide, so every console child an engine spawns
+  // (ollama's gpu probes, ffmpeg) opened its own visible window. windowsHide
+  // alone gives the engine a hidden console the whole tree inherits, and
+  // taskkill /T reaps by PID without needing a process group anyway.
+  return spawn(argv[0], argv.slice(1), { cwd, env, detached: !IS_WIN, windowsHide: true, stdio: ["ignore", fd, fd] });
 }
 
 function stopChild(child) {

--- a/desktop/src/windowsHide.test.mjs
+++ b/desktop/src/windowsHide.test.mjs
@@ -1,0 +1,59 @@
+// The desktop shell is a GUI process, so on Windows every console program it
+// spawns (taskkill, tar, pip, ollama...) pops up a console window unless the
+// spawn passes windowsHide: true. Those windows flashed on the user's screen at
+// every launch and quit before the option was added everywhere. The option is
+// ignored on other platforms, so there is never a reason to omit it -- this
+// test reads the shell's sources and fails on any spawn call that does.
+//
+// Run with: node --test desktop/src/windowsHide.test.mjs
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+const SHELL_FILES = [
+  join(SRC_DIR, "..", "main.js"),
+  ...readdirSync(SRC_DIR)
+    .filter((f) => f.endsWith(".js"))
+    .map((f) => join(SRC_DIR, f)),
+];
+
+// The full argument list of one spawn()/spawnSync() call, found by walking to
+// the parenthesis that closes the call -- the options object with windowsHide
+// sits inside it, usually a couple of lines below the opening line.
+function spawnCalls(code) {
+  const calls = [];
+  for (const m of code.matchAll(/\b(spawn|spawnSync)\s*\(/g)) {
+    let depth = 1;
+    let i = m.index + m[0].length;
+    while (i < code.length && depth > 0) {
+      if (code[i] === "(") depth++;
+      else if (code[i] === ")") depth--;
+      i++;
+    }
+    calls.push({
+      text: code.slice(m.index, i),
+      line: code.slice(0, m.index).split("\n").length,
+    });
+  }
+  return calls;
+}
+
+test("every spawn in the desktop shell hides its console window", () => {
+  let seen = 0;
+  for (const file of SHELL_FILES) {
+    const code = readFileSync(file, "utf8");
+    for (const { text, line } of spawnCalls(code)) {
+      seen++;
+      assert.ok(
+        text.includes("windowsHide"),
+        `${file}:${line} spawns without windowsHide: true -- on Windows this flashes a console window:\n${text}`,
+      );
+    }
+  }
+  // Were the shell ever refactored away from child_process, an empty scan
+  // would pass forever without checking anything -- fail loudly instead.
+  assert.ok(seen >= 3, `expected the shell's spawn calls, found ${seen}`);
+});


### PR DESCRIPTION
## Problem

On Windows, black console windows flashed on screen every time the app started or quit, and while jobs ran. Mac was unaffected.

## Cause

Two separate gaps, found by recording every visible console window during boot:

1. Console programs spawned from the GUI shell without `windowsHide: true` -- `taskkill` on every launch and quit, install commands (tar, pip, hf), and the temporary `ollama serve` during model pulls -- each opened a visible console window.
2. Engines were spawned with `detached: true`. Windows ignores `windowsHide` when `DETACHED_PROCESS` is set, so the engines ran without any console, and every console child they spawned (Ollama's GPU probes, llama-server) allocated its own visible window. This was the main source of the flashing.

## Fix

- Pass `windowsHide: true` in `forceKillTree`, the installer's `run()` helper, and the model-pull `ollama serve` spawn.
- Stop detaching engines on Windows (`detached: !IS_WIN`). A hidden console is inherited by the whole engine tree, so nothing it spawns can open a window. POSIX keeps the detached process group, and Windows cleanup always reaped by PID via `taskkill /T`, so nothing else changes.
- New source test (`windowsHide.test.mjs`) fails on any spawn call that omits `windowsHide`, so the next spawn added cannot regress this.

Behavior on Mac and Linux is unchanged: `windowsHide` is a no-op there and `detached` stays as it was.

## Testing

- All 166 desktop tests pass, including the new one.
- Verified on Windows 11 with a console-window recorder: 13 visible console windows during boot before the fix, zero after. Confirmed by hand across app start, quit, and a full dubbing run.