### PR TITLE
Fix the script assistant on Windows: prompt over stdin, stop the whole tree

### DIFF
--- a/app/agents/base.py
+++ b/app/agents/base.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from typing import Callable, Iterator, List, Optional
 
 # A GUI app does not inherit the login shell's PATH, so `claude` can be on the
@@ -263,13 +264,31 @@ _turn = None            # the _Turn on air, or None
 
 
 def _end(proc, grace: float = STOP_GRACE) -> None:
-    """Ask this child to go, and insist if it will not."""
+    """Ask this child to go, and insist if it will not.
+
+    On Windows the child is an npm .cmd shim, and terminate() only reaches the
+    shim (cmd.exe): the CLI under it kept streaming after Stop, and a stopped
+    Codex kept writing its conversation -- the "already has an active writer"
+    refusal on the very next message (2026-08-27). taskkill /T fells the whole
+    tree; CREATE_NO_WINDOW because taskkill is a console program launched from
+    a GUI app, and without it every stop flashed a console window.
+    """
     if proc.poll() is not None:
         return
-    try:
-        proc.terminate()
-    except OSError:
-        return
+    if sys.platform == "win32":
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                capture_output=True, timeout=10,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+        except (OSError, subprocess.SubprocessError):
+            pass  # the kill below is the backstop
+    else:
+        try:
+            proc.terminate()
+        except OSError:
+            return
     try:
         proc.wait(timeout=grace)
     except subprocess.TimeoutExpired:
@@ -308,30 +327,86 @@ def stop_turn(grace: float = STOP_GRACE) -> bool:
     return True
 
 
+# Codex marks a conversation "active writer" while a turn writes to it.
+# Windows cannot end a CLI gracefully -- terminate() is a hard kill there --
+# so a turn stopped mid-answer leaves that mark behind, and the very next
+# resume failed on its face with this text (code -32600, seen 2026-08-27).
+# The mark clears itself in a moment; one quiet retry is the whole cure.
+_STALE_LOCK = "already has an active writer"
+RETRY_DELAY = 1.5
+
+
 def run(binary: str, args: List[str], translate: Callable[[dict], List[dict]],
         cwd: Optional[str] = None, agent_name: str = "The assistant",
-        login_command: str = "") -> Iterator[dict]:
+        login_command: str = "",
+        input_text: Optional[str] = None) -> Iterator[dict]:
     """Spawn one turn and yield our events as they arrive.
+
+    `input_text` is the prompt, piped to the CLI's stdin (see the drivers'
+    stdin_text). It must never travel in `args`: on Windows the CLIs are npm
+    .cmd shims, and cmd.exe cuts a shim's command line at the first newline --
+    the prompt always has one, and everything after it was silently lost.
+
+    A turn that dies AT ONCE on Codex's stale conversation lock is respawned
+    once, silently, after a short wait. Only that: an error after anything has
+    already reached the panel is shown, and any other failure is shown the
+    first time -- retrying real errors would double their wait, and double the
+    work of anything that changes state.
 
     Yields an error event rather than raising: a failed turn is something the
     panel shows in a bubble, not a crash.
     """
+    for attempt in (0, 1):
+        yielded = False
+        retry = False
+        for event in _run_once(binary, args, translate, cwd=cwd,
+                               agent_name=agent_name,
+                               login_command=login_command,
+                               input_text=input_text):
+            if (attempt == 0 and not yielded
+                    and event.get("kind") == "error"
+                    and _STALE_LOCK in (event.get("detail") or "")):
+                retry = True
+                break
+            yielded = True
+            yield event
+        if not retry:
+            return
+        time.sleep(RETRY_DELAY)
+
+
+def _run_once(binary: str, args: List[str], translate: Callable[[dict], List[dict]],
+              cwd: Optional[str] = None, agent_name: str = "The assistant",
+              login_command: str = "",
+              input_text: Optional[str] = None) -> Iterator[dict]:
+    """One spawn of the CLI -- run() above decides whether it gets another."""
     try:
         proc = subprocess.Popen(
             [binary] + args,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            # Closed, not inherited: a CLI that reads stdin when it is open
-            # would sit there waiting on whatever terminal started the app.
-            stdin=subprocess.DEVNULL,
+            # With a prompt to send, a pipe that is closed right after it; the
+            # EOF is what tells the CLI the question is complete. Without one,
+            # closed outright -- a CLI that reads an open stdin would sit there
+            # waiting on whatever terminal started the app.
+            stdin=subprocess.PIPE if input_text is not None else subprocess.DEVNULL,
             cwd=cwd, text=True, encoding="utf-8", bufsize=1,
         )
     except OSError as e:
         yield {"kind": "error", "message": "Could not run the assistant: %s" % e}
         return
 
+    if input_text is not None:
+        try:
+            proc.stdin.write(input_text)
+            proc.stdin.close()
+        except OSError:
+            pass  # the CLI died before reading; its exit code says so below
+
     turn = _Turn(proc)
     _begin(turn)
-    timer = threading.Timer(TIMEOUT_SECONDS, proc.kill)
+    # _end, not proc.kill: on Windows kill() reaches only the .cmd shim and a
+    # timed-out CLI would keep running underneath it (same story as Stop).
+    timer = threading.Timer(TIMEOUT_SECONDS, _end, args=(proc,))
     timer.start()
     saw_done = False
     drained = False

--- a/app/agents/base.py
+++ b/app/agents/base.py
@@ -397,6 +397,9 @@ def _run_once(binary: str, args: List[str], translate: Callable[[dict], List[dic
 
     if input_text is not None:
         try:
+            # No newline translation: a text-mode pipe turns \n into \r\n on
+            # Windows, and the prompt should reach the CLI exactly as typed.
+            proc.stdin.reconfigure(newline="\n")
             proc.stdin.write(input_text)
             proc.stdin.close()
         except OSError:

--- a/app/agents/claude.py
+++ b/app/agents/claude.py
@@ -150,8 +150,23 @@ SYSTEM_PROMPT = (
 MODELS = ["fable", "opus", "sonnet", "haiku"]
 
 
-def command(prompt: str, mcp_config: str, resume: bool, model: str = "") -> List[str]:
-    """The command line to run for one message.
+def stdin_text(prompt: str) -> str:
+    """What run() pipes to the CLI's stdin: the question, verbatim.
+
+    The prompt used to ride argv after -p. On Windows the CLI is an npm .cmd
+    shim, and cmd.exe cuts a shim's command line at the first newline -- which
+    the prompt always has (job context + blank line + question). The question
+    AND every flag after it silently vanished: no --output-format left the
+    output unreadable ("(empty answer)" in the panel), and no tool fences left
+    the assistant running with its default tools. Piped to stdin, the text
+    never touches the command line on any platform.
+    """
+    return prompt
+
+
+def command(mcp_config: str, resume: bool, model: str = "") -> List[str]:
+    """The command line to run for one message. The question itself is not on
+    it -- see stdin_text.
 
     --strict-mcp-config matters as much as the deny list: without it the user's
     own MCP servers come along, so the assistant would reach tools this app
@@ -159,7 +174,7 @@ def command(prompt: str, mcp_config: str, resume: bool, model: str = "") -> List
     """
     tools = ",".join(MCP_PREFIX + name for name in TOOL_LABELS)
     args = [
-        "-p", prompt,
+        "-p",
         "--output-format", "stream-json",
         "--verbose",
         "--include-partial-messages",

--- a/app/agents/codex.py
+++ b/app/agents/codex.py
@@ -156,8 +156,21 @@ def _toml(value) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
-def command(prompt: str, mcp_config: str, resume: bool, model: str = "") -> List[str]:
-    """The command line to run for one message.
+def stdin_text(prompt: str) -> str:
+    """What run() pipes to the CLI's stdin: standing instructions, then the
+    question. Codex reads its prompt from stdin when the argument is absent.
+
+    Over stdin for the same reason as claude.stdin_text: on Windows the CLI is
+    an npm .cmd shim, and cmd.exe cuts a shim's command line at the first
+    newline -- this text is full of them. Codex has no --system-prompt, so the
+    standing instructions ride in front of the question.
+    """
+    return SYSTEM_PROMPT + "\n\n" + prompt
+
+
+def command(mcp_config: str, resume: bool, model: str = "") -> List[str]:
+    """The command line to run for one message. The prompt itself is not on
+    it -- see stdin_text.
 
     Codex has no --mcp-config, so the server written by base.write_mcp_config is
     read back here and handed over as -c overrides. --ignore-user-config is the
@@ -245,8 +258,4 @@ def command(prompt: str, mcp_config: str, resume: bool, model: str = "") -> List
     # --approve-for-me does the same as the two approval settings, but it is an
     # option of `codex exec` alone -- `codex exec resume` does not take it -- so
     # the -c form is the only one that works on both paths.
-    #
-    # Codex has no --system-prompt, so the standing instructions ride in front
-    # of the question.
-    args.append(SYSTEM_PROMPT + "\n\n" + prompt)
     return args

--- a/app/main.py
+++ b/app/main.py
@@ -1459,9 +1459,12 @@ async def agent_chat(body: AgentChatRequest, request: Request):
     api_url = str(request.base_url).rstrip("/")
     mcp_config = agent_base.write_mcp_config(AGENT_DIR, api_url)
     work_dir = os.path.dirname(mcp_config)
+    # The question goes to the CLI over stdin, never argv: on Windows the CLIs
+    # are npm .cmd shims, and cmd.exe cuts a shim's command line at the first
+    # newline -- which this text always has between job context and question.
+    prompt = driver.stdin_text(_with_job(body.message, body.job_id))
     try:
-        args = driver.command(_with_job(body.message, body.job_id),
-                              mcp_config, body.resume, body.model)
+        args = driver.command(mcp_config, body.resume, body.model)
     except (OSError, ValueError, KeyError) as e:
         # Everything else on this path answers with a bubble rather than a
         # stack trace, and building the command line should not be the one
@@ -1481,7 +1484,8 @@ async def agent_chat(body: AgentChatRequest, request: Request):
             try:
                 for event in agent_base.run(binary, args, driver.translate,
                                             cwd=work_dir, agent_name=meta["name"],
-                                            login_command=meta.get("login", "")):
+                                            login_command=meta.get("login", ""),
+                                            input_text=prompt):
                     events.put(event)
             finally:
                 events.put(None)      # whatever happened, the turn is over

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -94,7 +94,8 @@ def _capture(monkeypatch, tmp_path):
     """Run a turn with the CLI replaced, and hand back what was asked of it."""
     seen = {}
 
-    def fake_run(binary, args, translate, cwd=None, agent_name="", login_command=""):
+    def fake_run(binary, args, translate, cwd=None, agent_name="", login_command="",
+                 input_text=None):
         seen["binary"] = binary
         seen["args"] = args
         seen["translate"] = translate
@@ -102,6 +103,7 @@ def _capture(monkeypatch, tmp_path):
         # in, so a failed turn can name both.
         seen["agent_name"] = agent_name
         seen["login_command"] = login_command
+        seen["input_text"] = input_text
         yield {"kind": "done", "text": "ok"}
 
     monkeypatch.setattr(main.agent_base, "run", fake_run)
@@ -123,7 +125,10 @@ def test_a_turn_goes_to_the_backend_the_panel_named(monkeypatch, tmp_path):
     assert seen["binary"].endswith("codex")
     assert seen["args"][0] == "exec"           # Codex's own command line
     assert seen["translate"] is main.codex_agent.translate
-    assert "abc123" in seen["args"][-1]        # the job on screen went with it
+    # The job on screen went with the question -- over stdin, never argv (a
+    # newline in argv is where cmd.exe cut the .cmd shim's command line).
+    assert "abc123" in seen["input_text"]
+    assert not any("abc123" in a for a in seen["args"])
 
 
 def test_claude_still_gets_claudes_command_line(monkeypatch, tmp_path):

--- a/tests/test_agents_base.py
+++ b/tests/test_agents_base.py
@@ -7,6 +7,9 @@ the login checks are exercised against recorded output.
 import subprocess
 import sys
 import threading
+import time
+
+import pytest
 
 from app.agents import base
 
@@ -182,6 +185,105 @@ def test_a_cli_that_hangs_or_answers_nonsense_says_nothing_either_way(monkeypatc
     assert base.login_state("codex", "")["logged_in"] is None
     # And one we have no check for.
     assert base.login_state("nosuchcli", "/bin/nosuchcli")["logged_in"] is None
+
+
+# --- the prompt travels over stdin ------------------------------------------
+# On Windows both CLIs are npm .cmd shims, and cmd.exe cuts a shim's command
+# line at the first newline. The prompt always has one (job context + blank
+# line + question), so passed as an argument it lost the question and every
+# flag after it -- the panel answered "(empty answer)" with the tool fences
+# gone (2026-08-27). run() pipes it instead; argv stays newline-free.
+
+def test_the_prompt_is_piped_whole_including_its_newlines():
+    echo = ("import json, sys\n"
+            "print(json.dumps({'type': 'echo', 'got': sys.stdin.read()}))\n")
+    out = list(base.run(sys.executable, ["-c", echo],
+                        lambda e: [{"kind": "text", "text": e["got"]}]
+                        if e.get("type") == "echo" else [],
+                        input_text="(job: abc123)\n\n둘째 줄 질문"))
+    assert {"kind": "text", "text": "(job: abc123)\n\n둘째 줄 질문"} in out
+
+
+# --- stop fells the whole process tree --------------------------------------
+# On Windows the CLIs run behind npm .cmd shims, and terminate() only reached
+# the shim (cmd.exe): the CLI itself kept streaming after Stop, and a stopped
+# Codex kept writing its conversation -- which is what "already has an active
+# writer" was (2026-08-27). Stopping must end the children too.
+
+# A stand-in shim: spawns a grandchild that stamps a file forever, then waits
+# on it -- exactly the shape of cmd.exe wrapping node.
+SHIM_CLI = (
+    "import os, subprocess, sys\n"
+    "child = subprocess.Popen([sys.executable, '-c', '''\n"
+    "import os, sys, time\n"
+    "sys.stdout.write('{\"type\": \"hello\"}\\\\n')\n"
+    "sys.stdout.flush()\n"
+    "while True:\n"
+    "    open(os.environ['STAMP'], 'a').write('x')\n"
+    "    time.sleep(0.1)\n"
+    "'''], stdout=sys.stdout)\n"
+    "child.wait()\n")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="the shim problem is Windows's")
+def test_stop_ends_the_shims_children_too(tmp_path, monkeypatch):
+    stamp = tmp_path / "stamp"
+    monkeypatch.setenv("STAMP", str(stamp))
+    started = threading.Event()
+    out = []
+    turn = _drain(SHIM_CLI, lambda e: (started.set(), [])[1], out)
+    assert started.wait(20), "the stand-in shim never started"
+    assert base.stop_turn() is True
+    turn.join(20)
+    size = stamp.stat().st_size if stamp.exists() else 0
+    time.sleep(0.6)
+    grown = (stamp.stat().st_size if stamp.exists() else 0) - size
+    assert grown == 0, "the grandchild kept running after the stop"
+
+
+# --- a stale conversation lock is retried, not shown ------------------------
+# Windows cannot end a CLI gracefully (terminate there is a hard kill), so a
+# turn stopped mid-answer leaves Codex's conversation marked "already has an
+# active writer". The very next resume then failed on its face (2026-08-27).
+# The lock clears itself in a moment, so one quiet retry is the whole cure.
+
+# Fails with Codex's lock message until a marker file exists, then answers.
+# The marker doubles as proof that a second spawn actually happened.
+LOCKED_ONCE_CLI = (
+    "import os, sys\n"
+    "flag = os.environ['LOCK_FLAG']\n"
+    "if os.path.exists(flag):\n"
+    "    sys.stdout.write('{\"type\": \"fine\"}\\n')\n"
+    "else:\n"
+    "    open(flag, 'w').close()\n"
+    "    sys.stderr.write('thread/resume failed: thread 01a0 already has an "
+    "active writer (code -32600)\\n')\n"
+    "    sys.exit(1)\n")
+
+
+def test_a_stale_lock_is_retried_quietly(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCK_FLAG", str(tmp_path / "flag"))
+    monkeypatch.setattr(base, "RETRY_DELAY", 0.05)
+    out = list(base.run(sys.executable, ["-c", LOCKED_ONCE_CLI],
+                        lambda e: [{"kind": "text", "text": "ok"}]
+                        if e.get("type") == "fine" else []))
+    assert (tmp_path / "flag").exists(), "the first, failing spawn never ran"
+    assert {"kind": "text", "text": "ok"} in out
+    assert not any(e.get("kind") == "error" for e in out)
+
+
+def test_any_other_failure_is_not_retried(tmp_path, monkeypatch):
+    """Only the stale lock earns a second spawn: retrying a real failure would
+    double every error's wait and, for anything that changes state, its work."""
+    monkeypatch.setenv("RUN_COUNT", str(tmp_path / "runs"))
+    monkeypatch.setattr(base, "RETRY_DELAY", 0.05)
+    broken = ("import os, sys\n"
+              "open(os.environ['RUN_COUNT'], 'a').write('x')\n"
+              "sys.stderr.write('no such model')\n"
+              "sys.exit(1)\n")
+    out = list(base.run(sys.executable, ["-c", broken], lambda e: []))
+    assert any(e.get("kind") == "error" for e in out)
+    assert (tmp_path / "runs").read_text() == "x"
 
 
 # --- stopping the turn on air -----------------------------------------------

--- a/tests/test_agents_base.py
+++ b/tests/test_agents_base.py
@@ -195,8 +195,12 @@ def test_a_cli_that_hangs_or_answers_nonsense_says_nothing_either_way(monkeypatc
 # gone (2026-08-27). run() pipes it instead; argv stays newline-free.
 
 def test_the_prompt_is_piped_whole_including_its_newlines():
+    # Bytes, decoded as UTF-8 by hand: run() writes UTF-8, and the real CLIs
+    # read stdin as UTF-8 -- but this stand-in is Python, whose text stdin
+    # follows the locale (cp1252 on CI's Windows, which garbled the Korean).
     echo = ("import json, sys\n"
-            "print(json.dumps({'type': 'echo', 'got': sys.stdin.read()}))\n")
+            "got = sys.stdin.buffer.read().decode('utf-8')\n"
+            "print(json.dumps({'type': 'echo', 'got': got}))\n")
     out = list(base.run(sys.executable, ["-c", echo],
                         lambda e: [{"kind": "text", "text": e["got"]}]
                         if e.get("type") == "echo" else [],

--- a/tests/test_agents_claude.py
+++ b/tests/test_agents_claude.py
@@ -115,7 +115,7 @@ def test_lines_we_do_not_recognise_are_ignored():
 def test_the_command_fences_the_assistant_in():
     from app.agents.claude import command
 
-    args = command("고쳐줘", "/tmp/mcp.json", resume=False)
+    args = command("/tmp/mcp.json", resume=False)
     # Only our own MCP server: without this the user's personal MCP servers
     # would come along and hand the assistant tools this app never offered.
     assert "--strict-mcp-config" in args
@@ -130,7 +130,21 @@ def test_the_command_fences_the_assistant_in():
 def test_resuming_continues_the_same_conversation():
     from app.agents.claude import command
 
-    assert "-c" in command("또", "/tmp/mcp.json", resume=True)
+    assert "-c" in command("/tmp/mcp.json", resume=True)
+
+
+def test_the_question_never_rides_the_command_line():
+    """cmd.exe cuts a .cmd shim's command line at the first newline, and the
+    prompt always has one (job context + question). Passed as an argument on
+    Windows it lost the question AND every flag after it -- the panel answered
+    "(empty answer)" with the tool fences gone (2026-08-27). The prompt goes
+    over stdin instead, so nothing in argv can carry a newline."""
+    from app.agents.claude import command, stdin_text
+
+    args = command("/tmp/mcp.json", resume=False)
+    assert "-p" in args                       # print mode; the prompt arrives on stdin
+    assert all("\n" not in a for a in args)
+    assert stdin_text("첫 줄\n\n둘째 줄") == "첫 줄\n\n둘째 줄"
 
 
 def test_the_job_on_screen_is_handed_to_the_assistant():
@@ -180,11 +194,11 @@ def test_a_chosen_model_is_passed_as_an_alias():
     from app.agents.claude import MODELS, command
 
     assert "fable" in MODELS
-    args = command("고쳐줘", "/tmp/mcp.json", resume=False, model="fable")
+    args = command("/tmp/mcp.json", resume=False, model="fable")
     assert args[args.index("--model") + 1] == "fable"
 
 
 def test_an_unknown_model_is_ignored_rather_than_passed_on():
     from app.agents.claude import command
-    assert "--model" not in command("고쳐줘", "/tmp/mcp.json", resume=False, model="wat")
-    assert "--model" not in command("고쳐줘", "/tmp/mcp.json", resume=False)
+    assert "--model" not in command("/tmp/mcp.json", resume=False, model="wat")
+    assert "--model" not in command("/tmp/mcp.json", resume=False)

--- a/tests/test_agents_codex.py
+++ b/tests/test_agents_codex.py
@@ -141,7 +141,7 @@ def _mcp_config(tmp_path):
 def test_the_command_carries_our_mcp_server_and_leaves_the_user_config_alone(tmp_path):
     from app.agents.codex import command
 
-    args = command("고쳐줘", _mcp_config(tmp_path), resume=False)
+    args = command(_mcp_config(tmp_path), resume=False)
     assert args[0] == "exec"
     assert "--json" in args
     # The user's own ~/.codex/config.toml -- and every MCP server in it -- stays
@@ -151,7 +151,6 @@ def test_the_command_carries_our_mcp_server_and_leaves_the_user_config_alone(tmp
     assert "mcp_servers.persodub.command=" in joined
     assert "app.mcp_server" in joined
     assert "PERSODUB_API" in joined
-    assert args[-1].endswith("고쳐줘")
 
 
 def test_the_command_lets_a_tool_call_through_without_anyone_to_ask(tmp_path):
@@ -160,7 +159,7 @@ def test_the_command_lets_a_tool_call_through_without_anyone_to_ask(tmp_path):
     runs, answers, and quietly changes nothing."""
     from app.agents.codex import command
 
-    joined = " ".join(command("고쳐줘", _mcp_config(tmp_path), resume=False))
+    joined = " ".join(command(_mcp_config(tmp_path), resume=False))
     # Measured 2026-08-26: the reviewer is the load-bearing one. A real turn
     # with approval_policy="on-request" and NO reviewer got the same refusal
     # ("approval policy is never") and rewrote nothing, so this line cannot be
@@ -176,19 +175,25 @@ def test_the_command_lets_a_tool_call_through_without_anyone_to_ask(tmp_path):
 def test_the_command_keeps_the_users_skills_and_the_web_out(tmp_path):
     from app.agents.codex import command
 
-    joined = " ".join(command("고쳐줘", _mcp_config(tmp_path), resume=False))
+    joined = " ".join(command(_mcp_config(tmp_path), resume=False))
     assert "skills.include_instructions=false" in joined
     assert "tools.web_search=false" in joined
 
 
 def test_the_assistant_is_told_what_it_is_for(tmp_path):
     """Codex has no --system-prompt, so the standing instructions ride in front
-    of the question instead."""
+    of the question -- over stdin, like the question itself: cmd.exe cuts a
+    .cmd shim's command line at the first newline, and this text is full of
+    them (see test_the_question_never_rides_the_command_line in the claude
+    tests for the Windows failure this prevents)."""
     from app.agents.claude import SYSTEM_PROMPT
-    from app.agents.codex import command
+    from app.agents.codex import command, stdin_text
 
-    args = command("고쳐줘", _mcp_config(tmp_path), resume=False)
-    assert SYSTEM_PROMPT in args[-1]
+    text = stdin_text("고쳐줘")
+    assert SYSTEM_PROMPT in text
+    assert text.endswith("고쳐줘")
+    args = command(_mcp_config(tmp_path), resume=False)
+    assert all("\n" not in a for a in args)
 
 
 def test_resuming_continues_the_same_conversation(tmp_path):
@@ -196,7 +201,7 @@ def test_resuming_continues_the_same_conversation(tmp_path):
     agent folder -- so this can never pick up the user's own Codex session."""
     from app.agents.codex import command
 
-    args = command("또", _mcp_config(tmp_path), resume=True)
+    args = command(_mcp_config(tmp_path), resume=True)
     assert args[:4] == ["exec", "resume", "--last", "--json"]
 
 
@@ -207,7 +212,7 @@ def test_no_model_is_ever_asked_for(tmp_path):
     from app.agents.codex import MODELS, command
 
     assert MODELS == []
-    assert "-m" not in command("고쳐줘", _mcp_config(tmp_path), resume=False,
+    assert "-m" not in command(_mcp_config(tmp_path), resume=False,
                                model="gpt-5.5")
 
 
@@ -239,7 +244,7 @@ def test_the_environment_is_handed_over_as_a_toml_table(tmp_path):
     turn with `expected a map in mcp_servers.persodub.env` (2026-08-26)."""
     from app.agents.codex import command
 
-    args = command("고쳐줘", _mcp_config(tmp_path), resume=False)
+    args = command(_mcp_config(tmp_path), resume=False)
     env = next(a for a in args if a.startswith("mcp_servers.persodub.env="))
     assert '"PERSODUB_API" = "http://127.0.0.1:8765"' in env
     assert '"PERSODUB_API":' not in env  # the JSON form Codex refused
@@ -250,7 +255,7 @@ def test_the_users_own_execpolicy_is_left_alone(tmp_path):
     with the user's .rules file loaded -- so their own fence stays up."""
     from app.agents.codex import command
 
-    assert "--ignore-rules" not in command("고쳐줘", _mcp_config(tmp_path),
+    assert "--ignore-rules" not in command(_mcp_config(tmp_path),
                                            resume=False)
 
 


### PR DESCRIPTION
## Problem

On Windows the script assistant was broken three ways:

1. Asking anything showed "(empty answer)" -- and, invisibly, the assistant was running without its tool restrictions, output format, or system prompt.
2. The Stop button did not stop the answer.
3. Sending a new message while Codex was still answering failed with "thread already has an active writer".

## Cause

On Windows both CLIs are npm `.cmd` shims, and everything traces back to that:

- cmd.exe cuts a shim's command line at the first newline. The prompt always contains one (job context, blank line, question), so the question and every flag after it were silently dropped. Confirmed against the CLI's own conversation transcript: only the job-context line ever arrived.
- `terminate()` reaches only the shim (cmd.exe), not the CLI under it. The CLI kept streaming after Stop, and an interrupted Codex kept writing its conversation, which is exactly the "active writer" the next resume tripped over.

## Fix

- The prompt now travels over stdin on every platform; argv stays newline-free. Both CLIs read their prompt from stdin (verified against real runs).
- Ending a turn on Windows fells the whole process tree with `taskkill /T` (hidden window), the same way the desktop shell reaps its engines. The turn timeout uses the same path.
- A resume that still trips over a leftover conversation lock is respawned once, quietly, instead of surfacing the refusal.

## Testing

- Full Python suite passes (856 tests), including new coverage: multi-line prompt arrives whole over stdin, prompt never rides argv (both drivers), stop kills the shim's children (Windows), stale-lock retry succeeds, and other failures are not retried.
- Verified by hand on Windows 11 in the packaged app: multi-line Korean questions get real answers with the script tools working, Stop actually stops mid-answer, and interrupting Codex mid-answer no longer errors.
- macOS behavior is unchanged: no shim there, and stdin prompts are standard for both CLIs.
