### PR TITLE
Reinstall venv dependencies when an update changes the requirements

### DIFF
--- a/desktop/src/installSpec.js
+++ b/desktop/src/installSpec.js
@@ -3,6 +3,7 @@
 // All external effects (download/extract/run) come from ctx so tests and
 // PERSODUB_FAKE mode can substitute them.
 import { existsSync, mkdirSync, cpSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { KIT_ENV } from "./kitEnv.js";
@@ -219,16 +220,42 @@ export function buildSteps(ctx) {
     ? [["torch==2.8.0", "torchaudio==2.8.0", "--index-url", "https://download.pytorch.org/whl/cu128"]]
     : [];
   const okPath = (id) => k(".install", `${id}.ok`);
-  const markOk = (id) => {
+  const markOk = (id, note = "") => {
     mkdirSync(k(".install"), { recursive: true });
-    writeFileSync(okPath(id), "");
+    writeFileSync(okPath(id), note);
+  };
+
+  // Everything a venv step would install, as one fingerprint. The pip
+  // arguments alone are not enough: ["-r", file] means the FILE's contents,
+  // and an app update rewrites those files (payload step above) while the
+  // arguments stay word-for-word the same. The 0.4.0 update added `mcp` to
+  // requirements.txt and no updated machine ever installed it -- the venv
+  // steps skipped on their bare .ok markers, and the script assistant's tool
+  // server could not start. The marker now records this fingerprint, so a
+  // requirements change is what re-opens the step; an update that changes no
+  // requirements still skips it in full.
+  const pipFingerprint = (pipInstalls) => {
+    const words = [];
+    for (const args of pipInstalls) {
+      for (let i = 0; i < args.length; i++) {
+        words.push(args[i]);
+        if (args[i] === "-r") {
+          // The missing-file marker never matches a recorded hash, so a kit
+          // whose requirements file vanished re-runs rather than skips.
+          words.push(existsSync(args[i + 1]) ? readFileSync(args[i + 1], "utf8") : "(missing)");
+          i++;
+        }
+      }
+    }
+    return createHash("sha256").update(JSON.stringify(words)).digest("hex");
   };
 
   const venvStep = (id, title, bytes, venvName, pipInstalls) => ({
     id,
     title,
     bytes,
-    isDone: () => existsSync(okPath(id)),
+    isDone: () => existsSync(okPath(id))
+      && readFileSync(okPath(id), "utf8").trim() === pipFingerprint(pipInstalls),
     run: async (report) => {
       const venvDir = k(venvName);
       report(null, `Creating ${venvName}`);
@@ -243,7 +270,7 @@ export function buildSteps(ctx) {
       for (const args of pipInstalls) {
         await ctx.run([pip, "install", ...args], { onLine: (l) => report(null, l.slice(0, 120)) });
       }
-      markOk(id);
+      markOk(id, pipFingerprint(pipInstalls));
     },
   });
 

--- a/desktop/src/installSpec.test.mjs
+++ b/desktop/src/installSpec.test.mjs
@@ -181,6 +181,36 @@ test("venv-app runs venv + pip installs and marks done", async () => {
   assert.equal(await step.isDone(), true);
 });
 
+// The 0.4.0 update added `mcp` to requirements.txt and no updated machine ever
+// installed it: the venv steps skipped on a bare .ok marker while the payload
+// step had just replaced the requirements files, and the script assistant's
+// tool server could not start anywhere the app had updated rather than been
+// freshly installed. A venv step is only done when its marker records the same
+// installs it would run today.
+test("venv-app re-runs when its requirements change", async () => {
+  const argvs = [];
+  const ctx = freshCtx({ run: async (argv) => { argvs.push(argv.join(" ")); } });
+  mkdirSync(join(ctx.kitDir, "app"), { recursive: true });
+  writeFileSync(join(ctx.kitDir, "app", "requirements.txt"), "fastapi\n");
+  const step = byId(ctx)["venv-app"];
+  await step.run(() => {});
+  assert.equal(await step.isDone(), true);
+  const before = argvs.length;
+  // An app update rewrites the requirements file -- the step must come back.
+  writeFileSync(join(ctx.kitDir, "app", "requirements.txt"), "fastapi\nmcp\n");
+  assert.equal(await step.isDone(), false);
+  await step.run(() => {});
+  assert.ok(argvs.length > before, "the second run never installed anything");
+  assert.equal(await step.isDone(), true);
+});
+
+test("a bare marker from before the fingerprint counts as not done", async () => {
+  const ctx = freshCtx({ run: async () => {} });
+  mkdirSync(join(ctx.kitDir, ".install"), { recursive: true });
+  writeFileSync(join(ctx.kitDir, ".install", "venv-app.ok"), "");
+  assert.equal(await byId(ctx)["venv-app"].isDone(), false);
+});
+
 // transformers pins huggingface-hub <1.0; an unbounded -U upgrade pulls 1.x and
 // breaks the sidecar at import time. 0.34 is the first release with the hf CLI.
 test("venv-qwen keeps huggingface_hub below 1.0", async () => {


### PR DESCRIPTION
## Problem

On any machine that UPDATED to 0.4.x (rather than fresh-installing), the script assistant ran without its tools: the tool server needs the `mcp` package that 0.4.0 added to requirements.txt, and no updated machine ever installed it. The assistant answered with its tool-call syntax leaking into the chat as text, and every tool call failed. Fresh installs were fine, which is why it survived testing.

## Cause

The installer's venv steps mark completion with an empty `.ok` file and skip forever after. An app update rewrites the requirements files (the payload step does, every update), but the venv steps never look at them again, so new dependencies are never installed.

## Fix

The marker now records a fingerprint of everything the step would install: the pip arguments, with each `-r` entry replaced by that file's contents. A step is done only when its marker matches the current fingerprint, so:

- an update that changes requirements re-runs just the affected venv step;
- an update that changes nothing still skips it in full;
- the old empty markers match nothing, so every already-broken kit heals on its next update.

## Testing

- All 168 desktop tests pass, including two new ones: a venv step re-runs when its requirements file changes, and a bare pre-fingerprint marker no longer counts as done.
- The live path only runs when an update arrives, so the end-to-end check happens with the next release: two known-broken machines (one Windows, one macOS) are ready to confirm the reinstall fires and the assistant's tools come back.
