### PR TITLE
The update pill appears within seconds of launch, and the backend keeps its port

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -12,7 +12,7 @@ import { download } from "./src/download.js";
 import { uniqueName } from "./src/downloadPath.js";
 import { extractTarGz } from "./src/extract.js";
 import { run } from "./src/exec.js";
-import { resolveUpdateMode, resolveFeed } from "./src/updater.js";
+import { resolveUpdateMode, resolveFeed, nextUpdateState } from "./src/updater.js";
 import { findForeignLockers } from "./src/lockCheck.js";
 import { resolveAnalyticsMode, countEvent, classifyError } from "./src/analytics.js";
 import { IS_WIN } from "./src/platform.js";
@@ -20,6 +20,10 @@ import { IS_WIN } from "./src/platform.js";
 const HERE = dirname(fileURLToPath(import.meta.url));
 let engines = null;
 let updateDownloaded = false;
+// The update as last announced -- re-sent to the page on every load, so a
+// page that arrives after the check (boot) or reloads mid-download still
+// shows the right pill. Null until an update is found.
+let updateState = null;
 let bootedKitDir = null;   // for the dub counts, which arrive long after boot
 
 
@@ -66,7 +70,12 @@ function countUsage(event, kitDir, errorCode, step) {
 // forced. electron-updater validates the new build's code signature, which is
 // why signing came first. Errors are logged and swallowed: an update check
 // must never break a working app.
+let updaterStarted = false;
 async function startUpdater(win, kitDir) {
+  // Boot can run more than once (the error screen's Retry); the updater's
+  // listeners and its network check must not.
+  if (updaterStarted) return;
+  updaterStarted = true;
   // The documented off-switch (PERSODUB_DISABLE_UPDATE_CHECK=1) lives in the
   // kit's kit.env with the user's other settings -- read it from there, since
   // a GUI app's process.env never carries it.
@@ -84,10 +93,24 @@ async function startUpdater(win, kitDir) {
     const feed = resolveFeed(process.env);
     if (feed) autoUpdater.setFeedURL(feed);
     autoUpdater.autoDownload = true;
+    // A downloaded update applies on plain quit too, not only through the
+    // "Restart to update" button -- the next launch is simply the new version.
+    autoUpdater.autoInstallOnAppQuit = true;
+    const announce = (event, info) => {
+      const next = nextUpdateState(updateState, event, info);
+      if (next === updateState) return;
+      updateState = next;
+      if (!win.isDestroyed()) win.webContents.send("shell:update-state", updateState);
+    };
+    autoUpdater.on("update-available", (info) => {
+      console.log(`PERSODUB_UPDATE available ${info?.version ?? ""}`);
+      announce("update-available", info);
+    });
+    autoUpdater.on("download-progress", (info) => announce("download-progress", info));
     autoUpdater.on("update-downloaded", (info) => {
       updateDownloaded = true;
       console.log(`PERSODUB_UPDATE downloaded ${info?.version ?? ""}`);
-      win.webContents.send("shell:update-ready", { version: info?.version ?? "" });
+      announce("update-downloaded", info);
       // Test-only hook: lets the end-to-end update test apply the swap without
       // a human clicking the banner. (true, false) = silent, no relaunch --
       // the test verifies the version stamp on disk, and a relaunched app
@@ -255,6 +278,11 @@ async function boot(win) {
     console.log(`PERSODUB_KIT kitDir=${cfg.kitDir} version=${kitVersion ?? "unknown"}`);
   }
 
+  // The update check starts here, beside the engines, not after them: the
+  // engines take up to a minute to come up, and the check used to wait for
+  // that before even asking. Whatever it learns is re-sent on every page
+  // load below, so the app page gets it the moment it appears.
+  startUpdater(win, cfg.kitDir); // deliberately not awaited: boot never waits on the network
   await win.loadFile(join(HERE, "screens", "loading.html"));
   try {
     engines = await startEngines(cfg, {
@@ -265,7 +293,6 @@ async function boot(win) {
     console.log(`PERSODUB_READY ${engines.url}`);
     bootedKitDir = cfg.kitDir;
     countUsage("app_launch", cfg.kitDir);
-    startUpdater(win, cfg.kitDir); // deliberately not awaited: boot never waits on the network
   } catch (err) {
     // The kit installed fine and the app still cannot run. Such a machine fires
     // no other event -- install_failure's other codes do not apply and
@@ -340,6 +367,12 @@ app.whenReady().then(() => {
       contextIsolation: true,
       nodeIntegration: false,
     },
+  });
+  // Every page load -- the app page arriving after boot, or a reload mid
+  // download -- gets the update's current state again; announcements sent to
+  // the loading screen would otherwise be the last the app page never hears.
+  win.webContents.on("did-finish-load", () => {
+    if (updateState && !win.isDestroyed()) win.webContents.send("shell:update-state", updateState);
   });
   // Outbound links (the credit popup's Recharge button, Settings' "get a key") belong in
   // the user's own browser. This window has no chrome -- no address bar, no Back -- so

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -105,9 +105,12 @@ async function startUpdater(win, kitDir) {
     const feed = resolveFeed(process.env);
     if (feed) autoUpdater.setFeedURL(feed);
     autoUpdater.autoDownload = true;
-    // A downloaded update applies on plain quit too, not only through the
-    // "Restart to update" button -- the next launch is simply the new version.
-    autoUpdater.autoInstallOnAppQuit = true;
+    // A downloaded update applies on plain quit too -- but not on Windows:
+    // there the update is an NSIS run that fails, after the window is gone,
+    // whenever another program holds a file in the install folder. That path
+    // has a pre-flight (shell:restart-to-update below) and a quit handler
+    // cannot run it, so Windows keeps the button as the one way in.
+    autoUpdater.autoInstallOnAppQuit = !IS_WIN;
     const announce = (event, info) => {
       const next = nextUpdateState(updateState, event, info);
       if (next === updateState) return;
@@ -290,10 +293,11 @@ async function boot(win) {
     console.log(`PERSODUB_KIT kitDir=${cfg.kitDir} version=${kitVersion ?? "unknown"}`);
   }
 
-  // The update check starts here, beside the engines, not after them: the
-  // engines take up to a minute to come up, and the check used to wait for
-  // that before even asking. Whatever it learns is re-sent on every page
-  // load below, so the app page gets it the moment it appears.
+  // The update check starts here -- before the engines, which take up to a
+  // minute to come up and which the check used to wait on before even asking.
+  // On the install path it starts once the install above has succeeded, since
+  // that is what this line sits after. Whatever it learns is re-sent on every
+  // page load below, so the app page gets it the moment it appears.
   startUpdater(win, cfg.kitDir); // deliberately not awaited: boot never waits on the network
   await win.loadFile(join(HERE, "screens", "loading.html"));
   try {

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, dialog, ipcMain, screen, session, shell } from "electron";
 import { join, dirname, basename } from "node:path";
-import { existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { parseEnvFile, KIT_ENV, migrateKitEnv } from "./src/kitEnv.js";
 import { fileURLToPath } from "node:url";
 import { loadConfig, DEFAULTS, defaultKitDir, kitPathTooLong, notEnoughSpace, freeSpaceAt } from "./src/config.js";
@@ -70,6 +70,18 @@ function countUsage(event, kitDir, errorCode, step) {
 // forced. electron-updater validates the new build's code signature, which is
 // why signing came first. Errors are logged and swallowed: an update check
 // must never break a working app.
+// <userData>/ports.json -- {"backend": 51799}: the port the backend listened
+// on last time. Reused when free so the page's origin (and its localStorage:
+// the seen "What's new" version, timeline state, pane sizes) survives a
+// relaunch. Unreadable or missing just means "pick a free port", as before.
+const PORTS_FILE = () => join(app.getPath("userData"), "ports.json");
+function readRememberedPorts() {
+  try { return JSON.parse(readFileSync(PORTS_FILE(), "utf8")) || {}; } catch { return {}; }
+}
+function rememberPorts(ports) {
+  try { writeFileSync(PORTS_FILE(), JSON.stringify(ports)); } catch { /* a forgotten port costs one blank launch, never the boot */ }
+}
+
 let updaterStarted = false;
 async function startUpdater(win, kitDir) {
   // Boot can run more than once (the error screen's Retry); the updater's
@@ -288,7 +300,9 @@ async function boot(win) {
     engines = await startEngines(cfg, {
       logDir: join(app.getPath("userData"), "logs"),
       appVersion: app.getVersion(), // desktop/package.json -- the one place the version lives
+      preferredBackendPort: readRememberedPorts().backend,
     });
+    rememberPorts({ backend: engines.port });
     await win.loadURL(engines.url);
     console.log(`PERSODUB_READY ${engines.url}`);
     bootedKitDir = cfg.kitDir;

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -16,9 +16,11 @@ contextBridge.exposeInMainWorld("persodubShell", {
   // the step that silently didn't happen.
   relaunch: () => ipcRenderer.send("shell:relaunch"),
   onInstallProgress: (cb) => ipcRenderer.on("shell:install-progress", (_e, p) => cb(p)),
-  // Auto-update: main.js announces a downloaded update; the page shows the
-  // banner and the button hands control back here to apply it.
-  onUpdateReady: (cb) => ipcRenderer.on("shell:update-ready", (_e, info) => cb(info)),
+  // Auto-update: main.js announces the update's state -- {version, phase:
+  // "downloading" | "ready", pct} -- as it changes and again whenever the page
+  // loads, so the pill shows "downloading" within seconds of launch and turns
+  // into the restart button when the file is on disk.
+  onUpdateState: (cb) => ipcRenderer.on("shell:update-state", (_e, state) => cb(state)),
   restartToUpdate: () => ipcRenderer.send("shell:restart-to-update"),
   // Usage counts for finished dubs. The page hands over the raw log tail
   // because it cannot classify it -- main.js turns that into one published

--- a/desktop/src/freePort.js
+++ b/desktop/src/freePort.js
@@ -10,3 +10,18 @@ export function getFreePort() {
     srv.on("error", reject);
   });
 }
+
+// Last launch's port, if nothing else took it meanwhile; otherwise any free
+// one. The backend's port is the page's browser origin, and everything the
+// page keeps in localStorage (the seen "What's new" version, the timeline's
+// open state, pane sizes) lives under that origin -- a new port every launch
+// meant a blank slate every launch. Anything that is not a usable user port
+// (unset, 0, privileged, out of range) just means "pick a free one".
+export function getPreferredPort(preferred) {
+  if (!Number.isInteger(preferred) || preferred <= 1024 || preferred > 65535) return getFreePort();
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.once("error", () => resolve(getFreePort()));
+    srv.listen(preferred, "127.0.0.1", () => srv.close(() => resolve(preferred)));
+  });
+}

--- a/desktop/src/freePort.test.mjs
+++ b/desktop/src/freePort.test.mjs
@@ -12,3 +12,39 @@ test("returned port is bindable", async () => {
     srv.on("error", reject);
   });
 });
+
+// The backend's port used to be a fresh free one every launch, which made
+// every launch a new browser origin: localStorage (the "Updated to" notice's
+// seen-version, timeline state, pane sizes) came up empty each time. The
+// shell now asks for last launch's port first and only falls back to a
+// free one when something else holds it.
+import { getPreferredPort } from "./freePort.js";
+
+test("a free preferred port is returned as is", async () => {
+  const preferred = await getFreePort();
+  assert.equal(await getPreferredPort(preferred), preferred);
+});
+
+test("a busy preferred port yields a different, bindable port", async () => {
+  const busy = await getFreePort();
+  const holder = createServer();
+  await new Promise((resolve) => holder.listen(busy, "127.0.0.1", resolve));
+  try {
+    const port = await getPreferredPort(busy);
+    assert.notEqual(port, busy);
+    await new Promise((resolve, reject) => {
+      const srv = createServer();
+      srv.listen(port, "127.0.0.1", () => srv.close(resolve));
+      srv.on("error", reject);
+    });
+  } finally {
+    await new Promise((resolve) => holder.close(resolve));
+  }
+});
+
+test("no or nonsense preference just means a free port", async () => {
+  for (const bad of [undefined, null, 0, -1, 80, "abc", 70000]) {
+    const port = await getPreferredPort(bad);
+    assert.ok(Number.isInteger(port) && port > 1024, `got ${port} for ${bad}`);
+  }
+});

--- a/desktop/src/orchestrator.js
+++ b/desktop/src/orchestrator.js
@@ -2,7 +2,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync, openSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { parseEnvFile, KIT_ENV } from "./kitEnv.js";
-import { getFreePort } from "./freePort.js";
+import { getFreePort, getPreferredPort } from "./freePort.js";
 import { waitForHealth } from "./health.js";
 import { IS_WIN, venvBin, exeName, PATH_SEP } from "./platform.js";
 
@@ -79,7 +79,7 @@ export function sidecarArgv(kitDir, port) {
           "server:app", "--host", "127.0.0.1", "--port", String(port)];
 }
 
-export async function startEngines(cfg, { logDir, appVersion }) {
+export async function startEngines(cfg, { logDir, appVersion, preferredBackendPort }) {
   mkdirSync(logDir, { recursive: true });
   await killStalePids(logDir);
 
@@ -141,7 +141,9 @@ export async function startEngines(cfg, { logDir, appVersion }) {
       predicate: (b) => b.status === "ok",
     });
 
-    const backendPort = await getFreePort();
+    // Last launch's port when free (main.js remembers it), so the page keeps
+    // the same origin -- and its localStorage -- from one launch to the next.
+    const backendPort = await getPreferredPort(preferredBackendPort);
     const backendArgv = overrideMode
       ? substitute(cfg.backendCmd, backendPort)
       : [venvBin(join(cfg.kitDir, "app_venv"), "uvicorn"),
@@ -152,7 +154,7 @@ export async function startEngines(cfg, { logDir, appVersion }) {
       timeoutMs: cfg.backendHealthTimeoutMs,
     });
 
-    return { url: `http://127.0.0.1:${backendPort}`, pids: pids(), stopAll };
+    return { url: `http://127.0.0.1:${backendPort}`, port: backendPort, pids: pids(), stopAll };
   } catch (err) {
     stopAll();
     err.logDir = logDir;

--- a/desktop/src/orchestrator.test.mjs
+++ b/desktop/src/orchestrator.test.mjs
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { startEngines, killStalePids, applyBinDir, sidecarArgv } from "./orchestrator.js";
 import { DEFAULTS } from "./config.js";
 import { PATH_SEP, venvBin } from "./platform.js";
+import { getFreePort } from "./freePort.js";
 
 const FAKE = join(dirname(fileURLToPath(import.meta.url)), "..", "fake");
 
@@ -126,4 +127,16 @@ test("the sidecar is launched from the engines venv", () => {
   const argv = sidecarArgv("/k", 3901);
   assert.equal(argv[0], venvBin(join("/k", "engines_venv"), "uvicorn"));
   assert.deepEqual(argv.slice(1), ["server:app", "--host", "127.0.0.1", "--port", "3901"]);
+});
+
+test("the backend comes up on the preferred port when it is free, and says which port it used", async () => {
+  const logDir = mkdtempSync(join(tmpdir(), "odlog-"));
+  const preferred = await getFreePort();
+  const { url, port, stopAll } = await startEngines(fakeCfg(), { logDir, preferredBackendPort: preferred });
+  try {
+    assert.equal(port, preferred);
+    assert.ok(url.endsWith(`:${preferred}`), url);
+  } finally {
+    stopAll();
+  }
 });

--- a/desktop/src/updater.js
+++ b/desktop/src/updater.js
@@ -27,3 +27,27 @@ export function resolveFeed(env) {
   if (url) return { provider: "generic", url };
   return null;
 }
+
+/**
+ * The update as the page should see it, folded from electron-updater's
+ * events: {version, phase: "downloading" | "ready", pct}. Kept outside
+ * main.js so the two-step announcement ("found, downloading" first, "ready"
+ * once the file is on disk) is testable. Returns `prev` unchanged for events
+ * that carry nothing new -- progress before a version is known, or an event
+ * this shell does not announce.
+ */
+export function nextUpdateState(prev, event, info) {
+  if (event === "update-available" && info?.version) {
+    return { version: info.version, phase: "downloading", pct: 0 };
+  }
+  if (event === "download-progress" && prev?.version) {
+    // electron-updater reports progress many times a second; only a whole
+    // percent that actually moved is worth an IPC message to the page.
+    const pct = Math.round(Number(info?.percent) || 0);
+    return pct === prev.pct ? prev : { ...prev, pct };
+  }
+  if (event === "update-downloaded" && (info?.version || prev?.version)) {
+    return { version: info?.version || prev.version, phase: "ready", pct: 100 };
+  }
+  return prev;
+}

--- a/desktop/src/updater.test.mjs
+++ b/desktop/src/updater.test.mjs
@@ -35,3 +35,37 @@ test("PERSODUB_UPDATE_URL points the updater at a test feed", () => {
     url: "http://127.0.0.1:8099",
   });
 });
+
+// The shell now announces an update in two steps -- "found, downloading" and
+// "ready" -- and re-announces the current step whenever the page (re)loads.
+// The bookkeeping between electron-updater's events and what the page shows
+// is this pure reducer.
+import { nextUpdateState } from "./updater.js";
+
+test("update-available starts a downloading state with the version", () => {
+  assert.deepEqual(nextUpdateState(null, "update-available", { version: "0.5.2" }),
+    { version: "0.5.2", phase: "downloading", pct: 0 });
+});
+
+test("download-progress keeps the version and rounds the percent", () => {
+  const s = nextUpdateState({ version: "0.5.2", phase: "downloading", pct: 0 },
+    "download-progress", { percent: 41.6 });
+  assert.deepEqual(s, { version: "0.5.2", phase: "downloading", pct: 42 });
+});
+
+test("update-downloaded becomes ready at 100 even if progress never fired", () => {
+  const s = nextUpdateState(null, "update-downloaded", { version: "0.5.2" });
+  assert.deepEqual(s, { version: "0.5.2", phase: "ready", pct: 100 });
+});
+
+test("unknown events and a missing version leave the state alone", () => {
+  const prev = { version: "0.5.2", phase: "downloading", pct: 10 };
+  assert.equal(nextUpdateState(prev, "update-not-available", {}), prev);
+  assert.equal(nextUpdateState(null, "download-progress", { percent: 5 }), null,
+    "progress before a version is known is noise");
+});
+
+test("progress that rounds to the same percent is not a new state", () => {
+  const prev = { version: "0.5.2", phase: "downloading", pct: 42 };
+  assert.equal(nextUpdateState(prev, "download-progress", { percent: 42.4 }), prev);
+});

--- a/static/index.html
+++ b/static/index.html
@@ -1950,6 +1950,7 @@
 <script type="module">
 import { LANGUAGES, buildDubFormData, startDubJob, pollDubJob, cancelDubJob, resultUrl, parseProgress, applyEngineAvailability, probeSource, engineChips } from "/js/dubApi.mjs";
 import { gb, neededModelId, modelStatusLine, dubStartDialog, overallProgress, allReady } from "/js/modelsUi.mjs";
+import { updateBannerView } from "/js/updateBanner.mjs";
 
 const $ = (id) => document.getElementById(id);
 
@@ -3164,21 +3165,27 @@ uploadZone.addEventListener("drop", (e) => {
 });
 
 // ---------------- Auto-update banner (desktop shell only) ----------------
-// The shell announces a fully-downloaded update; outside Electron (plain
-// browser, tests) persodubShell is absent and none of this runs.
-if (window.persodubShell?.onUpdateReady) {
-  window.persodubShell.onUpdateReady((info) => {
+// The shell announces the update's state as it changes: "downloading N%"
+// within seconds of launch, then "ready" with the restart button once the
+// file is on disk. Outside Electron (plain browser, tests) persodubShell is
+// absent and none of this runs.
+if (window.persodubShell?.onUpdateState) {
+  window.persodubShell.onUpdateState((state) => {
+    const view = updateBannerView(state);
+    if (!view) return;
     let el = $("updateBanner");
     if (!el) {
       el = document.createElement("div");
       el.id = "updateBanner";
       el.className = "update-banner";
-      el.innerHTML = `<span></span><button type="button">Restart to update</button>`;
+      el.innerHTML = `<span></span><button type="button" hidden></button>`;
       el.querySelector("button").addEventListener("click", () => window.persodubShell.restartToUpdate());
       document.body.appendChild(el);
     }
-    el.querySelector("span").textContent =
-      `PersoDub ${info.version || "update"} is ready.`;
+    el.querySelector("span").textContent = view.text;
+    const btn = el.querySelector("button");
+    btn.hidden = !view.button;
+    if (view.button) btn.textContent = view.button;
     el.classList.add("shown");
   });
 }

--- a/ui/src/updateBanner.mjs
+++ b/ui/src/updateBanner.mjs
@@ -1,0 +1,12 @@
+// The update pill's words for one shell-reported state. The shell announces
+// an update twice -- when it is found (and downloading) and when the file is
+// on disk -- and this decides what each step says and whether the restart
+// button is offered. Pure: the page draws whatever this returns.
+export function updateBannerView(state) {
+  if (!state?.version) return null;
+  if (state.phase === "ready") {
+    return { text: `PersoDub ${state.version} is ready.`, button: "Restart to update" };
+  }
+  const pct = state.pct > 0 ? ` · ${state.pct}%` : "";
+  return { text: `Downloading PersoDub ${state.version}${pct}`, button: null };
+}

--- a/ui/src/updateBanner.test.mjs
+++ b/ui/src/updateBanner.test.mjs
@@ -1,0 +1,24 @@
+// What the update pill says at each step. Pure, so the wording is tested
+// without a shell: "found, downloading N%" first, then "ready" with a button.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { updateBannerView } from "./updateBanner.mjs";
+
+test("while downloading: version, percent, no button", () => {
+  assert.deepEqual(updateBannerView({ version: "0.5.2", phase: "downloading", pct: 42 }),
+    { text: "Downloading PersoDub 0.5.2 · 42%", button: null });
+});
+
+test("at zero percent the pill still names the version", () => {
+  assert.deepEqual(updateBannerView({ version: "0.5.2", phase: "downloading", pct: 0 }),
+    { text: "Downloading PersoDub 0.5.2", button: null });
+});
+
+test("when ready: restart button", () => {
+  assert.deepEqual(updateBannerView({ version: "0.5.2", phase: "ready", pct: 100 }),
+    { text: "PersoDub 0.5.2 is ready.", button: "Restart to update" });
+});
+
+test("no state means no pill", () => {
+  assert.equal(updateBannerView(null), null);
+});


### PR DESCRIPTION
Stacked on #27. Two launch-time fixes.

- **Update check starts beside the engines, not after them.** The pill shows "Downloading PersoDub 0.5.2 · 42%" within seconds, then "PersoDub 0.5.2 is ready." with Restart to update. State is re-sent on every page load. On macOS a downloaded update also applies on plain quit; Windows keeps the Restart button and its file-lock pre-flight.
- **The backend reuses last launch's port** (`<userData>/ports.json`) when it is free. A fresh port every launch meant a fresh browser origin — and an empty `localStorage` — every launch: the "Updated to x.y.z" notice never showed and every remembered layout reset.

Checked on device against a local update feed: downloading pill seen, restart applied, plain quit applied on macOS; two launches reused port 60828. Suites: desktop 188, UI 65.