### PR TITLE
Boot resumes an interrupted install; an update quotes an honest size

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -7,7 +7,7 @@ import { loadConfig, DEFAULTS, defaultKitDir, kitPathTooLong, notEnoughSpace, fr
 import { checkKit, readKitVersion } from "./src/engineCheck.js";
 import { killStalePids, startEngines } from "./src/orchestrator.js";
 import { buildSteps, bytesStillNeeded } from "./src/installSpec.js";
-import { runInstall } from "./src/installer.js";
+import { runInstall, openSteps } from "./src/installer.js";
 import { download } from "./src/download.js";
 import { uniqueName } from "./src/downloadPath.js";
 import { extractTarGz } from "./src/extract.js";
@@ -224,7 +224,21 @@ async function boot(win) {
       }
       cfg = { ...cfg, kitDir: freshKitDir };
     }
-    if (!checkKit(cfg.kitDir, kitVersion).ok) {
+    // checkKit sees files and a version, not whether the steps that produce
+    // them finished: the payload step writes KIT_VERSION first, so an install
+    // closed during the venv step looked "installed", the engines then failed
+    // to start, and Try again could never get back in (Windows, 2026-09-04).
+    // The installer's own step markers are the truth -- any open step reopens
+    // it, and it skips everything already done.
+    const kitOk = checkKit(cfg.kitDir, kitVersion).ok;
+    let unfinished = false;
+    if (kitOk && payload) {
+      const probe = buildSteps({ kitDir: cfg.kitDir, payloadDir: payload, download, extract: extractTarGz, run });
+      const open = await openSteps(probe);
+      unfinished = open.length > 0;
+      if (unfinished) console.log(`PERSODUB_KIT resuming an unfinished install: ${open.map((s) => s.id).join(", ")}`);
+    }
+    if (!kitOk || unfinished) {
       if (!payload) {
         await win.loadFile(join(HERE, "screens", "not-installed.html"), {
           query: { kitDir: cfg.kitDir, missing: checkKit(cfg.kitDir, kitVersion).missing.join(",") },

--- a/desktop/src/installSpec.js
+++ b/desktop/src/installSpec.js
@@ -284,7 +284,10 @@ export function buildSteps(ctx) {
   const venvStep = (id, title, bytes, venvName, pipInstalls) => ({
     id,
     title,
-    bytes,
+    // A venv that already exists is being updated: pip adds what the new list
+    // brings (hundreds of MB), not the full budget that includes torch. The
+    // budget is what the free-space preflight and the install title show.
+    bytes: existsSync(k(venvName)) ? Math.min(bytes, 0.5 * GB) : bytes,
     isDone: () => existsSync(okPath(id))
       && readFileSync(okPath(id), "utf8").trim() === pipFingerprint(pipInstalls),
     run: async (report) => {

--- a/desktop/src/installSpec.test.mjs
+++ b/desktop/src/installSpec.test.mjs
@@ -602,3 +602,15 @@ test("nothing is needed once every step is done", async () => {
   const steps = [{ id: "a", bytes: 5, isDone: () => true }];
   assert.equal(await bytesStillNeeded(steps), 0);
 });
+
+// On an update the engines venv already holds torch; the step only adds what
+// the new list brings. Quoting the full 2-9 GB budget in the install title
+// made a Windows user close a one-minute update (2026-09-04).
+test("venv-engines counts a small figure when the venv already exists", () => {
+  const ctx = freshCtx();
+  const fresh = byId(ctx)["venv-engines"].bytes;
+  mkdirSync(join(ctx.kitDir, "engines_venv"), { recursive: true });
+  const update = byId(ctx)["venv-engines"].bytes;
+  assert.ok(update < fresh, `update ${update} should be below fresh ${fresh}`);
+  assert.ok(update <= 0.5 * 1024 ** 3);
+});

--- a/desktop/src/installer.js
+++ b/desktop/src/installer.js
@@ -26,3 +26,16 @@ export async function runInstall(steps, { onProgress = () => {} } = {}) {
     onProgress({ stepId: step.id, title: step.title, state: "done", bytes: step.bytes });
   }
 }
+
+// The steps a kit still has to run -- not counting housekeeping steps
+// (verify:false), whose leftovers must never reopen the installer on every
+// launch. Boot asks this even when checkKit passes: that check sees files and
+// a version, not whether the step that produces them finished.
+export async function openSteps(steps) {
+  const open = [];
+  for (const step of steps) {
+    if (step.verify === false) continue;
+    if (!(await step.isDone())) open.push(step);
+  }
+  return open;
+}

--- a/desktop/src/installer.test.mjs
+++ b/desktop/src/installer.test.mjs
@@ -63,3 +63,24 @@ test("every progress event carries the step's bytes, so the screen can add up wh
     assert.equal(e.bytes, e.stepId === "a" ? 5 : 7);
   }
 });
+
+// A kit can pass the boot check (files present, version matching) with an
+// install still open: the payload step writes KIT_VERSION first, and a venv
+// step interrupted after it left the engines half-built (Windows, 2026-09-04).
+// The step markers are the truth; this is what boot asks before skipping the
+// installer.
+import { openSteps } from "./installer.js";
+
+test("openSteps names the steps still to run, ignoring housekeeping ones", async () => {
+  const steps = [
+    { id: "payload", isDone: () => true },
+    { id: "venv-engines", isDone: async () => false },
+    { id: "cleanup", verify: false, isDone: () => false },
+    { id: "kit-env", isDone: () => true },
+  ];
+  assert.deepEqual((await openSteps(steps)).map((s) => s.id), ["venv-engines"]);
+});
+
+test("openSteps is empty for a finished kit", async () => {
+  assert.deepEqual(await openSteps([{ id: "a", isDone: () => true }]), []);
+});


### PR DESCRIPTION
Found by the Windows update test of 644bc44 (2026-09-04).

- **An install closed midway could never be resumed.** The payload step writes `KIT_VERSION` first, and `checkKit` looks only at file presence and that version — so a kit interrupted during the venv step looked "installed", the engines then failed to start (`No module named 'qwen_tts'`), and Try again took the same path forever. Boot now asks the installer's own step markers (`openSteps`); any unfinished step reopens the installer, which skips everything already done. Housekeeping steps (`verify:false`) never trigger it.
- **The install title quoted the full venv budget on an update** ("Updating PersoDub · 9.5 GB" for a one-minute pip run), which is what made the tester close it. A venv step whose venv already exists now counts at most 0.5 GB.

Verified on macOS by staling the venv-engines marker with a matching KIT_VERSION: boot logged `resuming an unfinished install: venv-engines`, showed the update screen, and reached home in 17 s with the marker rewritten. Desktop suite 191/191.