### PR TITLE
0.5.4: Perso's own languages, download percent, and the fixes from the 0.5.3 release test

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,5 +52,6 @@ jobs:
           name: PersoDub-Setup-windows
           path: |
             desktop/dist/*.exe
+            desktop/dist/*.blockmap
             desktop/dist/latest.yml
           if-no-files-found: error

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -61,4 +61,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
         shell: bash
-        run: gh release upload "$TAG" desktop/dist/*.exe desktop/dist/latest.yml --clobber
+        run: gh release upload "$TAG" desktop/dist/*.exe desktop/dist/*.blockmap desktop/dist/latest.yml --clobber

--- a/app/api/dub.py
+++ b/app/api/dub.py
@@ -44,7 +44,7 @@ from typing import Optional
 import httpx
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
-from app import config, dub_launch, engines_status, media, runtime, state
+from app import dub_launch, engines_status, languages, media, runtime, state
 from app import models as model_store
 from app import setup as dub_setup
 from app.api._shared import script_work_dir, work_dir_of
@@ -126,14 +126,14 @@ def _today():
 _LANGUAGE_CODE = re.compile(r"^[A-Za-z]{2,8}([-_][A-Za-z0-9]{2,8})?$")
 
 
-def _valid_language_code(code: str) -> bool:
-    """A code the app knows (config.LANGUAGE_NAMES), region variant allowed:
-    "ko", "pt-BR" yes; "xx" no. The shape alone let "xx" start a job that
-    only failed at translation (2026-09-08)."""
+def _valid_language_code(code: str, dub_mode: str = "local") -> bool:
+    """A code the chosen path knows: local = config.LANGUAGE_NAMES (region
+    variant allowed: "pt-BR" is still Portuguese), perso = Perso's own list
+    (app/languages.py; "hi", "en-GB" yes there, not locally). The shape alone
+    let "xx" start a job that only failed at translation (2026-09-08)."""
     if not _LANGUAGE_CODE.match(code or ""):
         return False
-    base = re.split(r"[-_]", code)[0].lower()
-    return base in config.LANGUAGE_NAMES
+    return languages.lookup(dub_mode, code) is not None
 
 
 def _job_dir(title, lang_code):
@@ -713,7 +713,7 @@ def dub_start(
         # The cloud does everything -- the per-stage engine choices (and their
         # preflights, including the local-model 409) do not apply.
         stt_engine = sep_engine = translate_engine = None
-    if not _valid_language_code(language_code):
+    if not _valid_language_code(language_code, dub_mode):
         raise HTTPException(422, f"Unknown language_code: {language_code}")
     effective_translate_engine = "" if dub_mode == "perso" else (translate_engine or dub_setup.default_for("translator")).lower()
     translate_missing_id = None

--- a/app/api/misc.py
+++ b/app/api/misc.py
@@ -24,7 +24,7 @@ import httpx
 from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel
 
-from app import engines_status
+from app import engines_status, languages
 from app.engines.base import (
     SynthesisRequest,
     get_engine,
@@ -129,6 +129,14 @@ def tts_say(body: SayRequest):
 
 
 # --- What this machine can do, and what changed in this release -------------
+
+@router.get("/api/languages")
+def api_languages():
+    """The languages each dubbing path offers: local = the model's ten,
+    perso = Perso's list (asked daily, kept locally). One id per entry is
+    what the New project dropdown sends as language_code."""
+    return {"local": languages.local_languages(), "perso": languages.perso_languages()}
+
 
 @router.get("/api/whats-new")
 def whats_new():

--- a/app/api/results.py
+++ b/app/api/results.py
@@ -20,6 +20,7 @@ import logging
 import math
 import os
 import re
+import shutil
 import subprocess
 import sys
 from typing import Optional
@@ -388,6 +389,20 @@ def _stale(built: str, *sources: str) -> bool:
     return any(os.path.getmtime(src) > made for src in sources)
 
 
+def _drawn_differently(built: str, ass: str) -> bool:
+    """The .ass a file was burned from is kept beside it (<built>.ass); the
+    .ass we would burn today being different means an update changed how the
+    subtitles are drawn, and the file must be made again -- the sources'
+    clocks alone called it fresh after the 2026-09-08 font-size fix."""
+    try:
+        with open(built + ".ass", encoding="utf-8") as f:
+            kept = f.read()
+    except OSError:
+        return True
+    with open(ass, encoding="utf-8") as f:
+        return f.read() != kept
+
+
 @router.get("/api/dub/result/{jid}/subtitled")
 def dub_result_subtitled(jid: str, preset: Optional[str] = None, download: int = 0,
                          pos: Optional[float] = None, size: Optional[float] = None):
@@ -401,9 +416,9 @@ def dub_result_subtitled(jid: str, preset: Optional[str] = None, download: int =
     j, out, srt, work, preset, pos, size, sources, stored = _resolved_burn_inputs(
         jid, preset, pos, size)
     built = os.path.join(work, "subtitled-%s%s.mp4" % (preset, _pos_size_suffix(pos, size)))
-    if _stale(built, *sources):
-        ass = _write_burn_ass(srt, preset, pos, size, work, out,
-                              stored["boxWidth"], stored["widths"], stored["layout"])
+    ass = _write_burn_ass(srt, preset, pos, size, work, out,
+                          stored["boxWidth"], stored["widths"], stored["layout"])
+    if _stale(built, *sources) or _drawn_differently(built, ass):
         run = subprocess.run(
             ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
              "-i", out, "-vf", "ass=filename='%s'" % _filter_path(ass),
@@ -415,6 +430,7 @@ def dub_result_subtitled(jid: str, preset: Optional[str] = None, download: int =
             raise HTTPException(status_code=503,
                                 detail="ffmpeg could not subtitle this video (%s)."
                                        % (run.stderr or "no detail")[-120:].strip())
+        shutil.copyfile(ass, built + ".ass")
     filename = "dub_%s-sub-%s.mp4" % (_target_code(j), preset)
     headers = ({"Content-Disposition": 'attachment; filename="%s"' % filename}
                if download else None)
@@ -571,10 +587,10 @@ def dub_result_subtitle_preview(jid: str, preset: Optional[str] = None,
     j, out, srt, work, preset, pos, size, sources, stored = _resolved_burn_inputs(
         jid, preset, pos, size)
     built = os.path.join(work, "subtitle-preview-%s%s.jpg" % (preset, _pos_size_suffix(pos, size)))
-    if _stale(built, *sources):
+    ass = _write_burn_ass(srt, preset, pos, size, work, out,
+                          stored["boxWidth"], stored["widths"], stored["layout"])
+    if _stale(built, *sources) or _drawn_differently(built, ass):
         at = _first_srt_second(srt) + 0.5
-        ass = _write_burn_ass(srt, preset, pos, size, work, out,
-                              stored["boxWidth"], stored["widths"], stored["layout"])
         run = subprocess.run(
             ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
              "-ss", "%.3f" % at, "-copyts", "-i", out,
@@ -585,4 +601,5 @@ def dub_result_subtitle_preview(jid: str, preset: Optional[str] = None,
             raise HTTPException(status_code=503,
                                 detail="ffmpeg could not draw the preview (%s)."
                                        % (run.stderr or "no detail")[-120:].strip())
+        shutil.copyfile(ass, built + ".ass")
     return FileResponse(built, media_type="image/jpeg")

--- a/app/dub_launch.py
+++ b/app/dub_launch.py
@@ -23,7 +23,7 @@ import logging
 import os
 from typing import Optional
 
-from app import config, engines_status, media, perso_client, state
+from app import config, engines_status, languages, media, perso_client, state
 from app.jobs import JobCancelled
 from app.perso_client import (
     PersoCreditExhaustedError,
@@ -37,7 +37,17 @@ from app.source_fetch import fetch as _fetch_source
 logger = logging.getLogger("persodub.dub_launch")
 
 
-def language_name(code: str) -> str:
+def language_name(code: str, dub_mode: str = "local") -> str:
+    """The name a job shows for its target: Perso's own for its list ("Hindi",
+    "English (UK)"), the model's for the local ten; the code itself when
+    neither knows it."""
+    entry = languages.lookup(dub_mode, code)
+    if entry:
+        return entry["name"]
+    return _legacy_language_name(code)
+
+
+def _legacy_language_name(code: str) -> str:
     """The language's name for a code, or the code itself for one we don't know
     (a region variant, say) -- which is no worse than what we were given.
 
@@ -74,7 +84,11 @@ def run_cloud_dub(jid, video_path, out_path, source_code, target_code, num_speak
     if ws:
         log(f"   Perso workspace: {ws.get('name') or ws.get('seq')} (#{ws.get('seq')})")
     try:
-        pc.dub_video(video_path, out_path, source_code, target_code, num_speakers=num_speakers, log=log)
+        # The job's language_code is the screen's id (a region tag such as
+        # "en-GB" or a plain code); Perso wants the code and the tag apart.
+        entry = languages.lookup("perso", target_code) or {"code": target_code, "tag": None}
+        tag = {"target_tag": entry["tag"]} if entry.get("tag") else {}
+        pc.dub_video(video_path, out_path, source_code, entry["code"], num_speakers=num_speakers, log=log, **tag)
         # The Perso project number is how the script viewer (and later the
         # agent) finds this job's sentences again -- persist it with the job.
         seq = getattr(pc, "last_dub_project_seq", None)
@@ -125,7 +139,7 @@ def work_for(job, *, cancel_check, on_notice, voices_only=False,
     video_path = os.path.join(work, "input.mp4")
     out_path = os.path.join(work, "dubbed.mp4")
     language_code = job.get("language_code") or "en"
-    language = job.get("language") or language_name(language_code)
+    language = job.get("language") or language_name(language_code, job.get("dub_mode") or "local")
     srt_path = _in_folder(work, "sub.srt")
     source_srt_path = _in_folder(work, "source.srt")
     trim = job.get("trim")

--- a/app/languages.py
+++ b/app/languages.py
@@ -1,0 +1,115 @@
+"""The languages a dub can be made in, per path.
+
+Local dubbing knows the ten Qwen3-TTS speaks (config.LANGUAGE_NAMES). Perso's
+cloud dubbing knows what Perso says it knows: 77 entries on 2026-09-08,
+three of them regional variants told apart by a tag (en-GB, es-ES, pt-PT).
+The screen sends one id per language -- the tag when there is one, else the
+code -- and this module turns it back into what each path needs.
+
+The Perso list is asked of the API once a day and kept beside the workspace;
+when the API cannot be reached (no key, offline) the last answer is used,
+and before any answer the copy shipped with the app (app/perso_languages.json,
+taken from the same endpoint).
+"""
+import json
+import os
+import re
+import time
+from typing import Optional
+
+from app import config
+
+BUNDLED = os.path.join(os.path.dirname(__file__), "perso_languages.json")
+CACHE_NAME = "perso_languages.json"
+MAX_AGE = 24 * 3600
+_CODE = re.compile(r"^[A-Za-z]{2,8}([-_][A-Za-z0-9]{2,8})?$")
+
+
+def local_languages() -> list:
+    """[{id, code, name, tag}] for the local path: the model's ten, in the
+    product's order (English, Korean, then the rest as configured)."""
+    return [{"id": c, "code": c, "name": n, "tag": None} for c, n in config.LANGUAGE_NAMES.items()]
+
+
+def _with_ids(entries) -> list:
+    return [{"id": (e.get("tag") or e["code"]), "code": e["code"], "name": e["name"], "tag": e.get("tag")}
+            for e in entries if e.get("code") and e.get("name")]
+
+
+def _cache_path() -> str:
+    from app import state
+    return os.path.join(state.WORKSPACE, CACHE_NAME)
+
+
+def _read(path: str) -> Optional[list]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            d = json.load(f)
+        langs = d.get("languages") if isinstance(d, dict) else d
+        return _with_ids(langs) if isinstance(langs, list) and langs else None
+    except (OSError, ValueError, TypeError, AttributeError):
+        return None
+
+
+def _fetch() -> Optional[list]:
+    """Perso's own list, only the AUDIO_ENGINE_V3 entries (the engine the app
+    dubs with), without the "auto" pseudo-language. None when it cannot be had."""
+    try:
+        from app import perso_client
+        from app.settings_env import current_value
+        key = current_value("PERSO_API_KEY")
+        if not key:
+            return None
+        import httpx
+        r = httpx.get(perso_client.BASE_URL + "/video-translator/api/v1/languages",
+                      headers=perso_client._key_headers(key), timeout=10)
+        r.raise_for_status()
+        raw = r.json().get("languages") or []
+        langs = [{"code": x["code"], "name": x["name"],
+                  "tag": None if x.get("languageTag") in (None, "", "default") else x["languageTag"]}
+                 for x in raw if x.get("code") != "auto" and "AUDIO_ENGINE_V3" in (x.get("supportedTtsModels") or [])]
+        return _with_ids(langs) or None
+    except Exception:
+        return None
+
+
+def perso_languages(refresh: bool = True) -> list:
+    """[{id, code, name, tag}] for Perso dubbing. Fresh from the API when the
+    kept copy is older than a day (or missing) and the API answers; otherwise
+    the kept copy; otherwise the bundled one."""
+    path = _cache_path()
+    fresh = os.path.exists(path) and (time.time() - os.path.getmtime(path)) < MAX_AGE
+    if refresh and not fresh:
+        langs = _fetch()
+        if langs:
+            try:
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump({"fetched": time.strftime("%Y-%m-%d"), "languages": langs}, f, ensure_ascii=False)
+            except OSError:
+                pass
+            return langs
+    return _read(path) or _read(BUNDLED) or []
+
+
+def languages_for(dub_mode: str) -> list:
+    return perso_languages() if dub_mode == "perso" else local_languages()
+
+
+def lookup(dub_mode: str, lang_id: str) -> Optional[dict]:
+    """The entry an id names on this path, or None. Local ids may carry a
+    region the model ignores ("pt-BR" is still Portuguese)."""
+    lang_id = (lang_id or "").strip()
+    if not _CODE.match(lang_id):
+        return None
+    if dub_mode == "perso":
+        low = lang_id.lower()
+        for e in perso_languages():
+            if e["id"].lower() == low:
+                return e
+        return None
+    base = re.split(r"[-_]", lang_id)[0].lower()
+    for e in local_languages():
+        if e["code"] == base:
+            return {**e, "id": lang_id}
+    return None

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -31,6 +31,22 @@ BACKUP_COUNT = 3
 LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 
 
+class _ClientWentAway(logging.Filter):
+    """Drops asyncio's report of a client that hung up mid-response.
+
+    On Windows the proactor loop logs "Exception in callback
+    _ProactorBasePipeTransport._call_connection_lost" with a
+    ConnectionResetError traceback every time the page closes a request early
+    (a video seek, a reload). Nothing went wrong on our side; three of these
+    sat in backend.log after one afternoon (2026-09-08)."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        text = record.getMessage()
+        if record.exc_info and record.exc_info[1] is not None:
+            text += " " + type(record.exc_info[1]).__name__
+        return not ("_call_connection_lost" in text or "ConnectionResetError" in text)
+
+
 def configure_logging() -> logging.Logger:
     """Give the "persodub" logger its handlers. Safe to call twice.
 
@@ -46,6 +62,9 @@ def configure_logging() -> logging.Logger:
     logger.setLevel(logging.DEBUG if os.environ.get("PERSODUB_DEBUG") == "1" else logging.INFO)
     if logger.handlers:
         return logger
+    asyncio_log = logging.getLogger("asyncio")
+    if not any(isinstance(f, _ClientWentAway) for f in asyncio_log.filters):
+        asyncio_log.addFilter(_ClientWentAway())
 
     formatter = logging.Formatter(LOG_FORMAT)
     console = logging.StreamHandler(sys.stderr)

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -23,7 +23,7 @@ from typing import List, Optional
 import httpx
 from mcp.server.mcpserver import MCPServer
 
-from app.config import LANGUAGE_NAMES
+from app import languages
 from app.dub_script import edit_line, export_srt, load_lines
 
 API = os.environ.get("PERSODUB_API", "http://127.0.0.1:8000")
@@ -331,10 +331,10 @@ def queue_dub(video_path: str, target_language: str, dub_mode: str = "local",
         raise ValueError('dub_mode must be "local" or "perso"')
     if translator not in ("", "gemma", "hunyuan", "gemini"):
         raise ValueError('translator must be "gemma", "hunyuan", "gemini" or empty')
-    code = (target_language or "").lower()
-    if code not in LANGUAGE_NAMES:
-        raise ValueError("target_language must be one of: %s"
-                         % " ".join(sorted(LANGUAGE_NAMES)))
+    code = (target_language or "").strip()
+    if languages.lookup(dub_mode, code) is None:
+        known = [e["id"] for e in languages.languages_for(dub_mode)]
+        raise ValueError("target_language must be one of: %s" % " ".join(sorted(known)))
     path = os.path.expanduser(video_path)
     if not confirm:
         # The estimate route already measures the video and, for perso, the
@@ -363,7 +363,7 @@ def queue_dub(video_path: str, target_language: str, dub_mode: str = "local",
                 "seconds": seconds}
     if not os.path.isfile(path):
         raise ValueError("No such video: %s" % video_path)
-    fields = {"language": LANGUAGE_NAMES[code], "language_code": code}
+    fields = {"language": languages.lookup(dub_mode, code)["name"], "language_code": code}
     if dub_mode == "perso":
         fields["dub_mode"] = "perso"
     if source_language:

--- a/app/perso_client.py
+++ b/app/perso_client.py
@@ -390,7 +390,8 @@ class PersoClient:
     def dub_video(self, video_path: str, out_path: str,
                   source_code: Optional[str], target_code: str,
                   num_speakers: Optional[int] = None,
-                  space_seq: Optional[int] = None, log=None) -> str:
+                  space_seq: Optional[int] = None, log=None,
+                  target_tag: Optional[str] = None) -> str:
         """Full cloud dub: upload -> translate project -> poll -> download.
 
         The whole pipeline runs on Perso's side (translation, voices, mix);
@@ -411,7 +412,10 @@ class PersoClient:
                 "isVideoProject": True,
                 # "auto" is the server's own detect-the-source value.
                 "sourceLanguageCode": source_code or "auto",
-                "targetLanguages": [{"languageCode": target_code, "ttsModel": "AUDIO_ENGINE_V3"}],
+                # languageTag tells Perso's regional variants apart (en-GB,
+                # es-ES, pt-PT); the plain code alone means its default region.
+                "targetLanguages": [{"languageCode": target_code, "ttsModel": "AUDIO_ENGINE_V3",
+                                     **({"languageTag": target_tag} if target_tag else {})}],
                 "numberOfSpeakers": int(num_speakers) if num_speakers else 1,
                 "preferredSpeedType": "GREEN",
             },

--- a/app/perso_languages.json
+++ b/app/perso_languages.json
@@ -1,0 +1,390 @@
+{
+ "fetched": "2026-09-08",
+ "languages": [
+  {
+   "code": "en",
+   "name": "English (US)",
+   "tag": null
+  },
+  {
+   "code": "pt",
+   "name": "Portuguese (Brazil)",
+   "tag": null
+  },
+  {
+   "code": "es",
+   "name": "Spanish (Mexico)",
+   "tag": null
+  },
+  {
+   "code": "hi",
+   "name": "Hindi",
+   "tag": null
+  },
+  {
+   "code": "fr",
+   "name": "French",
+   "tag": null
+  },
+  {
+   "code": "it",
+   "name": "Italian",
+   "tag": null
+  },
+  {
+   "code": "es",
+   "name": "Spanish (Spain)",
+   "tag": "es-ES"
+  },
+  {
+   "code": "th",
+   "name": "Thai",
+   "tag": null
+  },
+  {
+   "code": "de",
+   "name": "German",
+   "tag": null
+  },
+  {
+   "code": "ja",
+   "name": "Japanese",
+   "tag": null
+  },
+  {
+   "code": "ru",
+   "name": "Russian",
+   "tag": null
+  },
+  {
+   "code": "ar",
+   "name": "Arabic",
+   "tag": null
+  },
+  {
+   "code": "hy",
+   "name": "Armenian",
+   "tag": null
+  },
+  {
+   "code": "af",
+   "name": "Afrikaans",
+   "tag": null
+  },
+  {
+   "code": "as",
+   "name": "Assamese",
+   "tag": null
+  },
+  {
+   "code": "az",
+   "name": "Azerbaijani",
+   "tag": null
+  },
+  {
+   "code": "be",
+   "name": "Belarusian",
+   "tag": null
+  },
+  {
+   "code": "bn",
+   "name": "Bengali",
+   "tag": null
+  },
+  {
+   "code": "bs",
+   "name": "Bosnian",
+   "tag": null
+  },
+  {
+   "code": "bg",
+   "name": "Bulgarian",
+   "tag": null
+  },
+  {
+   "code": "ca",
+   "name": "Catalan",
+   "tag": null
+  },
+  {
+   "code": "ceb",
+   "name": "Cebuano",
+   "tag": null
+  },
+  {
+   "code": "ny",
+   "name": "Chichewa",
+   "tag": null
+  },
+  {
+   "code": "zh",
+   "name": "Chinese",
+   "tag": null
+  },
+  {
+   "code": "hr",
+   "name": "Croatian",
+   "tag": null
+  },
+  {
+   "code": "cs",
+   "name": "Czech",
+   "tag": null
+  },
+  {
+   "code": "da",
+   "name": "Danish",
+   "tag": null
+  },
+  {
+   "code": "nl",
+   "name": "Dutch",
+   "tag": null
+  },
+  {
+   "code": "en",
+   "name": "English (UK)",
+   "tag": "en-GB"
+  },
+  {
+   "code": "et",
+   "name": "Estonian",
+   "tag": null
+  },
+  {
+   "code": "fil",
+   "name": "Filipino",
+   "tag": null
+  },
+  {
+   "code": "fi",
+   "name": "Finnish",
+   "tag": null
+  },
+  {
+   "code": "gl",
+   "name": "Galician",
+   "tag": null
+  },
+  {
+   "code": "ka",
+   "name": "Georgian",
+   "tag": null
+  },
+  {
+   "code": "el",
+   "name": "Greek",
+   "tag": null
+  },
+  {
+   "code": "gu",
+   "name": "Gujarati",
+   "tag": null
+  },
+  {
+   "code": "ha",
+   "name": "Hausa",
+   "tag": null
+  },
+  {
+   "code": "he",
+   "name": "Hebrew",
+   "tag": null
+  },
+  {
+   "code": "hu",
+   "name": "Hungarian",
+   "tag": null
+  },
+  {
+   "code": "is",
+   "name": "Icelandic",
+   "tag": null
+  },
+  {
+   "code": "id",
+   "name": "Indonesian",
+   "tag": null
+  },
+  {
+   "code": "ga",
+   "name": "Irish",
+   "tag": null
+  },
+  {
+   "code": "jv",
+   "name": "Javanese",
+   "tag": null
+  },
+  {
+   "code": "kn",
+   "name": "Kannada",
+   "tag": null
+  },
+  {
+   "code": "kk",
+   "name": "Kazakh",
+   "tag": null
+  },
+  {
+   "code": "ko",
+   "name": "Korean",
+   "tag": null
+  },
+  {
+   "code": "ky",
+   "name": "Kyrgyz",
+   "tag": null
+  },
+  {
+   "code": "lv",
+   "name": "Latvian",
+   "tag": null
+  },
+  {
+   "code": "ln",
+   "name": "Lingala",
+   "tag": null
+  },
+  {
+   "code": "lt",
+   "name": "Lithuanian",
+   "tag": null
+  },
+  {
+   "code": "lb",
+   "name": "Luxembourgish",
+   "tag": null
+  },
+  {
+   "code": "mk",
+   "name": "Macedonian",
+   "tag": null
+  },
+  {
+   "code": "ms",
+   "name": "Malay",
+   "tag": null
+  },
+  {
+   "code": "ml",
+   "name": "Malayalam",
+   "tag": null
+  },
+  {
+   "code": "mr",
+   "name": "Marathi",
+   "tag": null
+  },
+  {
+   "code": "ne",
+   "name": "Nepali",
+   "tag": null
+  },
+  {
+   "code": "no",
+   "name": "Norwegian",
+   "tag": null
+  },
+  {
+   "code": "ps",
+   "name": "Pashto",
+   "tag": null
+  },
+  {
+   "code": "fa",
+   "name": "Persian",
+   "tag": null
+  },
+  {
+   "code": "pl",
+   "name": "Polish",
+   "tag": null
+  },
+  {
+   "code": "pt",
+   "name": "Portuguese (Portugal)",
+   "tag": "pt-PT"
+  },
+  {
+   "code": "pa",
+   "name": "Punjabi",
+   "tag": null
+  },
+  {
+   "code": "ro",
+   "name": "Romanian",
+   "tag": null
+  },
+  {
+   "code": "sr",
+   "name": "Serbian",
+   "tag": null
+  },
+  {
+   "code": "sd",
+   "name": "Sindhi",
+   "tag": null
+  },
+  {
+   "code": "sk",
+   "name": "Slovak",
+   "tag": null
+  },
+  {
+   "code": "sl",
+   "name": "Slovenian",
+   "tag": null
+  },
+  {
+   "code": "so",
+   "name": "Somali",
+   "tag": null
+  },
+  {
+   "code": "sw",
+   "name": "Swahili",
+   "tag": null
+  },
+  {
+   "code": "sv",
+   "name": "Swedish",
+   "tag": null
+  },
+  {
+   "code": "ta",
+   "name": "Tamil",
+   "tag": null
+  },
+  {
+   "code": "te",
+   "name": "Telugu",
+   "tag": null
+  },
+  {
+   "code": "tr",
+   "name": "Turkish",
+   "tag": null
+  },
+  {
+   "code": "uk",
+   "name": "Ukrainian",
+   "tag": null
+  },
+  {
+   "code": "ur",
+   "name": "Urdu",
+   "tag": null
+  },
+  {
+   "code": "vi",
+   "name": "Vietnamese",
+   "tag": null
+  },
+  {
+   "code": "cy",
+   "name": "Welsh",
+   "tag": null
+  }
+ ]
+}

--- a/app/subtitle_ass.py
+++ b/app/subtitle_ass.py
@@ -133,6 +133,20 @@ def _rect(align, x, y, box, w_px, h_px):
             % (align, x, y, box_col.upper(), alpha, w_px, w_px, h_px, h_px))
 
 
+# libass reads a Style's Fontsize as the font's cell height (ascent + descent),
+# the VSFilter way, so a font whose cell is taller than its em comes out that
+# much smaller than the page drew it -- the page measures in true em. The
+# burn fonts' cells, from their OS/2 metrics and confirmed by rendering ten
+# capital H on 2026-09-08 (Chromium 668 px vs libass 542 px on Mac, 530 px on
+# Windows at Fontsize 100). A font not listed here is drawn unscaled.
+FONT_CELL = {"Apple SD Gothic Neo": 1.2, "Malgun Gothic": 1.33, "Noto Sans CJK KR": 1.448}
+
+# Fonts that ship a regular and a bold face only: the browser gives weight 600
+# the bold face, libass the regular one, so White Box came out thin on
+# Windows. For these the layout's weight snaps to \b1 / \b0.
+TWO_WEIGHT_FONTS = {"Malgun Gothic"}
+
+
 def build_ass(cues, preset_id, *, width, height, pos=None, size=None,
               font="Arial", box_width=None, line_widths=None, layout=None):
     """The whole .ass document for one video's subtitles.
@@ -169,8 +183,11 @@ def build_ass(cues, preset_id, *, width, height, pos=None, size=None,
                      else _color(p["outline"]))
     back = _color(box["color"], box["opacity"]) if box else _color("000000")
     safe_font = re.sub(r"[,\r\n{}]", " ", font).strip()
+    # Only the Style's Fontsize takes the cell scale (FONT_CELL); boxes,
+    # paddings and offsets stay in font_px, the em the page measured with.
+    style_px = round(font_px * FONT_CELL.get(font, 1.0))
     style = ("Style: Base,%s,%d,%s,&H000000FF,%s,%s,%d,0,0,0,100,100,0,0,%d,%d,%d,%d,%d,%d,%d,1"
-             % (safe_font, font_px, _color(p["primary"]), outline_color, back,
+             % (safe_font, style_px, _color(p["primary"]), outline_color, back,
                 1 if p["bold"] else 0, border_style, outline, shadow, align,
                 round(width * 0.06), round(width * 0.06), margin_v))
 
@@ -191,7 +208,11 @@ def build_ass(cues, preset_id, *, width, height, pos=None, size=None,
         lines = list(lay["lines"]) if lay else [text]
         # The weight the page drew at (\b<weight>, which libass honours); the
         # preset's bold flag alone left White Box thinner than on screen.
-        wt = "\\b%d" % lay["weight"] if lay and lay.get("weight") else ""
+        if lay and lay.get("weight"):
+            wt = ("\\b%d" % (1 if lay["weight"] >= 600 else 0) if font in TWO_WEIGHT_FONTS
+                  else "\\b%d" % lay["weight"])
+        else:
+            wt = ""
         if p["uppercase"]:
             text = text.upper()
             lines = [l.upper() for l in lines]

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -7,7 +7,7 @@ import { loadConfig, DEFAULTS, defaultKitDir, kitPathTooLong, notEnoughSpace, fr
 import { checkKit, readKitVersion } from "./src/engineCheck.js";
 import { killStalePids, startEngines } from "./src/orchestrator.js";
 import { buildSteps, bytesStillNeeded, baseSteps, packSteps, packInstalled, packInstallingMarker, PACKS } from "./src/installSpec.js";
-import { runInstall, openSteps, packPercent } from "./src/installer.js";
+import { runInstall, openSteps, packPercent, downloadInterrupted, DOWNLOAD_INTERRUPTED } from "./src/installer.js";
 import { cancelCurrent } from "./src/exec.js";
 import { readRuntime } from "./src/runtimeFile.js";
 import { download } from "./src/download.js";
@@ -24,6 +24,9 @@ let engines = null;
 // The boot's install context (kit, bundled payload, downloader), kept so the
 // pack IPC below can run a pack's steps from the same table later.
 let installCtx = null;
+// The old-path kit main.js walked away from at boot (issue #6); the cleanup
+// step removes it once its models are carried over.
+let abandonedKitDir = null;
 
 // The shell's own lines go to a file as well as the console: a packaged app
 // has no console, and the one question a support log could not answer on
@@ -252,6 +255,7 @@ async function boot(win) {
       } catch (err) {
         console.warn("PERSODUB_KIT could not carry models over:", String((err && err.message) || err));
       }
+      abandonedKitDir = cfg.kitDir;
       cfg = { ...cfg, kitDir: freshKitDir };
     }
     // checkKit sees files and a version, not whether the steps that produce
@@ -267,7 +271,7 @@ async function boot(win) {
     // ollama-runtime keep being refreshed the way they always were; a pack
     // that was never installed is left alone here -- a later task adds the
     // IPC to install one on demand.
-    installCtx = payload ? { kitDir: cfg.kitDir, payloadDir: payload, download, extract: extractTarGz, run } : null;
+    installCtx = payload ? { kitDir: cfg.kitDir, payloadDir: payload, download, extract: extractTarGz, run, abandonedKitDir } : null;
     // A pack's "installing" stamp left by a crash would read as downloading forever.
     for (const p of PACKS) rmSync(packInstallingMarker(cfg.kitDir, p.id), { force: true });
     const all = installCtx ? buildSteps(installCtx) : null;
@@ -528,7 +532,7 @@ app.whenReady().then(() => {
       } catch (err) {
         const full = String((err && err.message) || err);
         shellLog(`PERSODUB_PACK install ${id} failed: ${full}`);
-        return { ok: false, reason: packCancelled ? "Cancelled." : lastReason(full) };
+        return { ok: false, reason: packCancelled ? "Cancelled." : downloadInterrupted(full) ? DOWNLOAD_INTERRUPTED : lastReason(full) };
       }
       if (engines && engines.startPack) {
         // The last step's line would sit in the dialog for the ~40 s the
@@ -618,7 +622,9 @@ app.whenReady().then(() => {
     // quitAndInstall bypasses will-quit in some paths -- stop the engines
     // explicitly first so no uvicorn is orphaned across the swap.
     if (engines) engines.stopAll();
-    electronUpdater.autoUpdater.quitAndInstall();
+    // (silent, relaunch): without the flags the NSIS wizard opened and asked
+    // for three clicks (user, Next, Finish) on 2026-09-08. Mac ignores them.
+    electronUpdater.autoUpdater.quitAndInstall(true, true);
   });
   guardedBoot();
 });

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -516,12 +516,18 @@ app.whenReady().then(() => {
       // The page gets the pack's overall percent on every event (installer.js
       // packPercent), not the running step's own -- a pip step has none.
       const done = new Set();
+      let lastPct = 0;
       try {
         await runInstall(steps, {
           onProgress: (p) => {
             if (p.state === "start" || p.state === "done" || p.state === "error") shellLog(`PERSODUB_PACK ${id} ${p.stepId} ${p.state}${p.detail ? ": " + p.detail.slice(0, 300) : ""}`);
             if (p.state === "done" || p.state === "skipped") done.add(p.stepId);
-            const pct = packPercent(steps, done, p.stepId, p.state === "progress" ? p.pct : null);
+            // A progress line without a percent (unpacking, a pip line) keeps
+            // the pack's last one: the dialog fell back to 0% for those (2026-09-08).
+            const pct = p.state === "progress" && p.pct == null
+              ? lastPct
+              : packPercent(steps, done, p.stepId, p.state === "progress" ? p.pct : null);
+            lastPct = pct;
             if (!win.isDestroyed()) win.webContents.send("shell:install-progress", { ...p, pack: id, pct });
           },
         });

--- a/desktop/src/installSpec.js
+++ b/desktop/src/installSpec.js
@@ -319,7 +319,14 @@ export async function bytesStillNeeded(steps) {
 // removed once venv-engines succeeded (this step sits right after it), and
 // the step stays open until every one is gone -- a locked file on Windows
 // just means it is retried next launch.
-const LEFTOVERS = (k) => [
+// ctx.abandonedKitDir: the kit at the pre-0.3.0 path (Electron's userData)
+// that main.js redirected away from, carrying its models/ over. It stayed
+// behind holding ~3 GB with nothing telling the user it was safe to delete
+// (issue #6). Removed only once models/ is gone from it, so a failed carry-over
+// never costs the models.
+const LEFTOVERS = (k, ctx = {}) => [
+  ...(ctx.abandonedKitDir && !existsSync(join(ctx.abandonedKitDir, "models"))
+    ? [{ path: ctx.abandonedKitDir, recursive: true }] : []),
   { path: k("qwen_venv"), recursive: true },                       // the retired voice venv
   { path: k("downloads", "python.tar.gz") },                         // archives, already extracted
   { path: k("downloads", "ollama.tgz") },
@@ -532,9 +539,9 @@ export function buildSteps(ctx) {
       title: "Cleaning up",
       bytes: 0,
       verify: false,   // a locked leftover is dead weight, never a failed install
-      isDone: () => LEFTOVERS(k).every((l) => !existsSync(l.path)),
+      isDone: () => LEFTOVERS(k, ctx).every((l) => !existsSync(l.path)),
       run: async (report) => {
-        for (const l of LEFTOVERS(k)) {
+        for (const l of LEFTOVERS(k, ctx)) {
           if (!existsSync(l.path)) continue;
           report(null, `Removing ${basename(l.path)}`);
           try {

--- a/desktop/src/installSpec.test.mjs
+++ b/desktop/src/installSpec.test.mjs
@@ -704,3 +704,24 @@ import { packInstallingMarker } from "./installSpec.js";
 test("the installing stamp sits beside the install's own stamps, named for the pack", () => {
   assert.equal(packInstallingMarker("/kit", "engine"), join("/kit", ".install", "engine.installing"));
 });
+
+test("cleanup removes the kit abandoned on the path move once its models were carried over (issue #6)", async () => {
+  const ctx = freshCtx();
+  const old = join(ctx.kitDir, "..", "old-kit");
+  mkdirSync(join(old, "python"), { recursive: true });
+  writeFileSync(join(old, "python", "bin"), "x");
+  const step = byId({ ...ctx, abandonedKitDir: old })["cleanup"];
+  assert.equal(await step.isDone(), false);
+  await step.run(() => {});
+  assert.equal(existsSync(old), false);
+  assert.equal(await step.isDone(), true);
+});
+
+test("cleanup keeps an abandoned kit that still holds its models", async () => {
+  const ctx = freshCtx();
+  const old = join(ctx.kitDir, "..", "old-kit-with-models");
+  mkdirSync(join(old, "models", "whisper"), { recursive: true });
+  const step = byId({ ...ctx, abandonedKitDir: old })["cleanup"];
+  await step.run(() => {});
+  assert.equal(existsSync(join(old, "models", "whisper")), true, "models never deleted by cleanup");
+});

--- a/desktop/src/installer.js
+++ b/desktop/src/installer.js
@@ -36,6 +36,17 @@ export async function runInstall(steps, { onProgress = () => {} } = {}) {
 // it counts as 0 until it finishes -- the percent still moves from step to
 // step). This is the number the page shows for a pack, the way it shows a
 // model's, because "Downloading AI engine…" with no figure read as stuck.
+// A pack step's failure text as the dialog should show it. A download that
+// broke mid-way (Hugging Face reset it twice on a slow office line,
+// 2026-09-08) surfaced as a Python exception with byte counts; the person
+// only needs to know that pressing Download and Start resumes it. Anything
+// else keeps the tool's own last line (main.js lastReason).
+export const DOWNLOAD_INTERRUPTED = "The download was interrupted. Click Download and Start to pick up where it left off.";
+const NETWORK_MARKS = /IncompleteRead|ChunkedEncodingError|Connection broken|ConnectionResetError|ConnectionError|ReadTimeout|timed out|ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN|getaddrinfo|Network is unreachable|RemoteDisconnected|ProtocolError|Max retries exceeded/;
+export function downloadInterrupted(message) {
+  return NETWORK_MARKS.test(String(message || ""));
+}
+
 export function packPercent(steps, doneIds, currentId, currentPct) {
   const total = steps.reduce((n, s) => n + (s.bytes || 0), 0);
   if (!total) return null;

--- a/desktop/src/installer.test.mjs
+++ b/desktop/src/installer.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { runInstall } from "./installer.js";
+import { runInstall, downloadInterrupted, DOWNLOAD_INTERRUPTED } from "./installer.js";
 
 function step(id, { done = false, fail = false, completes = true } = {}, log) {
   let ran = false;
@@ -94,4 +94,13 @@ test("packPercent weighs the steps by size and moves from step to step even with
   assert.equal(packPercent(steps, new Set(["venv-engines"]), "models", 50), 88);   // 800 + 75 of 1000
   assert.equal(packPercent(steps, new Set(["venv-engines", "models", "nonverbal-weights"]), null, null), 100);
   assert.equal(packPercent([{ id: "x", bytes: 0 }], new Set(), "x", 10), null, "no sizes, no figure");
+});
+
+test("a download that broke mid-way is reported as interrupted, other failures keep their own text", () => {
+  const hf = "AI engine: requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(50682952 bytes read, 33342488 more expected)', IncompleteRead(...))";
+  assert.equal(downloadInterrupted(hf), true);
+  assert.equal(downloadInterrupted("Error: getaddrinfo ENOTFOUND huggingface.co"), true);
+  assert.equal(downloadInterrupted("ERROR: No matching distribution found for torch==2.8.0"), false);
+  assert.equal(downloadInterrupted(""), false);
+  assert.match(DOWNLOAD_INTERRUPTED, /Download and Start/);
 });

--- a/desktop/src/lockCheck.js
+++ b/desktop/src/lockCheck.js
@@ -24,6 +24,10 @@ export function lockProbeScript(installDir) {
   const dir = String(installDir).replace(/'/g, "''");
   return `
 $ErrorActionPreference = 'Stop'
+# The console code page is cp949 on Korean Windows and Node reads stdout as
+# UTF-8: without this, a locker's Korean description ("Microsoft Defender
+# 바이러스 백신") reached the dialog as ������ (2026-09-08).
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 try {
   Add-Type -TypeDefinition @'
 using System;

--- a/desktop/src/lockCheck.test.mjs
+++ b/desktop/src/lockCheck.test.mjs
@@ -70,3 +70,12 @@ test("findForeignLockers fails open when the probe blows up", async () => {
   });
   assert.deepEqual(got, []);
 });
+
+test("lockProbeScript makes PowerShell answer in UTF-8, so Korean app names survive", () => {
+  // The dialog showed "Close Microsoft Defender ������ first" on a Korean
+  // Windows (2026-09-08): stdout came out in the console code page.
+  const script = lockProbeScript("C:\\x");
+  const enc = script.indexOf("[Console]::OutputEncoding = [System.Text.Encoding]::UTF8");
+  assert.ok(enc > 0);
+  assert.ok(enc < script.indexOf("Add-Type"), "set before anything prints");
+});

--- a/static/index.html
+++ b/static/index.html
@@ -2306,7 +2306,10 @@ function paintModelStatusLines(rows) {
   }
   const dl = rows.find((m) => m.state === "downloading" && m.progress != null)
           || rows.find((m) => m.state === "downloading");
-  $("topbarDl").hidden = !dl;
+  // The chip stands in for the download dialog, not beside it: it shows only
+  // once Hide closed the dialog (the dialog itself carries the percent).
+  const dialogOpen = $("modelsNeededOverlay").classList.contains("open");
+  $("topbarDl").hidden = !dl || dialogOpen;
   if (dl) $("topbarDl").textContent = `${dl.name} · ${dl.progress ?? 0}%`;
 }
 

--- a/tests/test_dub_start_preflight.py
+++ b/tests/test_dub_start_preflight.py
@@ -258,3 +258,14 @@ def test_a_language_code_the_app_does_not_know_is_refused(monkeypatch, _kit):
     r = _start({"language_code": "xx"})
     assert r.status_code == 422 and "language_code" in r.json()["detail"]
     assert _start({"language_code": "pt-BR"}).status_code == 200, "a region variant of a known language"
+
+
+def test_perso_dubbing_accepts_persos_languages_and_local_does_not(monkeypatch, _kit):
+    # Hindi and British English exist on Perso's list only (app/languages.py).
+    monkeypatch.setattr(dub_api, "_run_cloud_dub", lambda *a, **kw: None)
+    monkeypatch.setattr(perso_client, "PersoClient", lambda: type("C", (), {
+        "dubbing_spaces": lambda self: [{"seq": 1}], "space_seq": 1})())
+    for code in ("hi", "en-GB"):
+        r = _start({"language_code": code, "dub_mode": "perso"})
+        assert r.status_code == 200, (code, r.text)
+    assert _start({"language_code": "hi"}).status_code == 422

--- a/tests/test_export_subtitled.py
+++ b/tests/test_export_subtitled.py
@@ -11,6 +11,13 @@ from app import engines_status
 from app.api import dub as dub_api
 from app.api import results as results_api
 from app.main import app
+from app.subtitle_ass import FONT_CELL
+
+
+def _style_px(em_px):
+    """The Style's Fontsize for an em of em_px on this platform's burn font:
+    libass sizes by the font's cell, so build_ass scales it up (FONT_CELL)."""
+    return round(em_px * FONT_CELL.get(results_api._BURN_FONT, 1.0))
 
 client = TestClient(app, base_url="http://127.0.0.1")
 
@@ -176,7 +183,8 @@ def test_subtitled_takes_a_font_size(monkeypatch, tmp_path):
     ran, jid, work = _done_job(monkeypatch, tmp_path)
     r = client.get(f"/api/dub/result/{jid}/subtitled?preset=clean&size=150")
     assert r.status_code == 200
-    assert "Base,Arial,52," in _ass(work).split("Style: ")[1][:40] or ",52," in _ass(work)  # 1080 * .032 * 1.5
+    style = [l for l in _ass(work).splitlines() if l.startswith("Style: Base,")][0]
+    assert style.split(",")[2] == str(_style_px(52))   # em 1080 * .032 * 1.5
     assert ran.calls[0][-1] == str(work / "subtitled-clean-s150.mp4")
     # 300 is a legal size now (user wanted bigger); past it is still nonsense.
     assert client.get(f"/api/dub/result/{jid}/subtitled?preset=clean&size=300").status_code == 200
@@ -188,7 +196,7 @@ def test_subtitle_preview_takes_size_and_position_together(monkeypatch, tmp_path
     r = client.get(f"/api/dub/result/{jid}/subtitle_preview?preset=variety&pos=30&size=80")
     assert r.status_code == 200
     ass = _ass(work)
-    assert ",42," in ass                # neon-yellow's .049 * 1080 * 0.8
+    assert ",%d," % _style_px(42) in ass   # neon-yellow's .049 * 1080 * 0.8
     assert ",756," in ass               # (100-30)% of 1080
     assert ran.calls[0][-1] == str(work / "subtitle-preview-neon-yellow-p30-s80.jpg")
 
@@ -249,7 +257,7 @@ def test_subtitled_reads_the_stored_settings(monkeypatch, tmp_path):
     r = client.get(f"/api/dub/result/{jid}/subtitled")
     assert r.status_code == 200
     ass = _ass(work)
-    assert "&H0000E6FF&" in ass and ",756," in ass and ",64," in ass
+    assert "&H0000E6FF&" in ass and ",756," in ass and ",%d," % _style_px(64) in ass
     assert "-neon-yellow-p30-s120.mp4" in ran.calls[0][-1]
 
 

--- a/tests/test_export_subtitled.py
+++ b/tests/test_export_subtitled.py
@@ -300,3 +300,18 @@ def test_the_pages_layout_reaches_the_burn(monkeypatch, tmp_path):
     # font 35 px on the 1080p fallback canvas: 10 em = 350 wide, 3 em = 105 tall
     assert "l 350 0 l 350 105 l 0 105" in ass
     assert "원래\\N번역" in ass
+
+
+def test_subtitled_is_burned_again_when_an_update_draws_it_differently(monkeypatch, tmp_path):
+    # Nothing of the job changed, but the app did (2026-09-08: the font-size
+    # fix): the .ass kept beside the file no longer matches, so it is rebuilt
+    # once, and the next ask finds it fresh again.
+    ran, jid, work = _done_job(monkeypatch, tmp_path)
+    assert client.get(f"/api/dub/result/{jid}/subtitled?preset=neon-yellow").status_code == 200
+    assert len(ran.calls) == 1
+    assert (work / "subtitled-neon-yellow.mp4.ass").read_text(encoding="utf-8") == _ass(work)
+    monkeypatch.setattr(results_api, "_BURN_FONT", "Some Other Font")
+    assert client.get(f"/api/dub/result/{jid}/subtitled?preset=neon-yellow").status_code == 200
+    assert len(ran.calls) == 2
+    assert client.get(f"/api/dub/result/{jid}/subtitled?preset=neon-yellow").status_code == 200
+    assert len(ran.calls) == 2

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,0 +1,51 @@
+"""The per-path language lists (app/languages.py)."""
+import json
+import os
+import time
+
+from app import languages, state
+
+
+def test_local_is_the_models_ten_in_product_order():
+    ids = [e["id"] for e in languages.local_languages()]
+    assert ids[:2] == ["en", "ko"] and len(ids) == 10
+    assert all(e["tag"] is None for e in languages.local_languages())
+
+
+def test_bundled_perso_list_is_perso_v3_minus_auto_with_region_tags(monkeypatch):
+    monkeypatch.setattr(languages, "_fetch", lambda: None)
+    langs = languages.perso_languages()
+    ids = {e["id"] for e in langs}
+    assert "auto" not in ids
+    assert {"hi", "th", "ar", "en", "en-GB", "es-ES", "pt-PT"} <= ids
+    assert len(langs) >= 70
+    gb = next(e for e in langs if e["id"] == "en-GB")
+    assert gb == {"id": "en-GB", "code": "en", "name": "English (UK)", "tag": "en-GB"}
+
+
+def test_perso_list_is_fetched_once_a_day_then_kept(monkeypatch, tmp_path):
+    monkeypatch.setattr(state, "WORKSPACE", str(tmp_path))
+    calls = []
+    fresh = [{"id": "zz", "code": "zz", "name": "Zed", "tag": None}]
+    monkeypatch.setattr(languages, "_fetch", lambda: (calls.append(1), fresh)[1])
+    assert languages.perso_languages() == fresh
+    assert languages.perso_languages() == fresh            # kept copy, no second call
+    assert len(calls) == 1
+    kept = json.load(open(os.path.join(str(tmp_path), languages.CACHE_NAME), encoding="utf-8"))
+    assert kept["languages"][0]["code"] == "zz"
+    # A day later the API is asked again; if it fails the kept copy stands.
+    os.utime(os.path.join(str(tmp_path), languages.CACHE_NAME), (time.time() - 2 * languages.MAX_AGE,) * 2)
+    monkeypatch.setattr(languages, "_fetch", lambda: (calls.append(1), None)[1])
+    assert languages.perso_languages() == fresh
+    assert len(calls) == 2
+
+
+def test_lookup_knows_each_path_apart(monkeypatch):
+    monkeypatch.setattr(languages, "_fetch", lambda: None)
+    assert languages.lookup("local", "ko")["name"] == "Korean"
+    assert languages.lookup("local", "pt-BR")["code"] == "pt"     # region ignored locally
+    assert languages.lookup("local", "hi") is None                  # the model cannot speak it
+    assert languages.lookup("perso", "hi")["name"] == "Hindi"
+    assert languages.lookup("perso", "EN-gb")["tag"] == "en-GB"     # case-insensitive
+    assert languages.lookup("perso", "xx") is None
+    assert languages.lookup("perso", "../etc") is None

--- a/tests/test_logging_noise.py
+++ b/tests/test_logging_noise.py
@@ -1,0 +1,37 @@
+"""asyncio's client-disconnect report stays out of the log (2026-09-08)."""
+import logging
+
+from app import logging_setup
+
+
+class _Catch(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+def test_client_disconnect_noise_is_dropped_and_real_asyncio_errors_kept():
+    logging_setup.configure_logging()
+    log = logging.getLogger("asyncio")
+    catch = _Catch()
+    log.addHandler(catch)
+    try:
+        log.error("Exception in callback _ProactorBasePipeTransport._call_connection_lost(None)")
+        try:
+            raise ConnectionResetError(10054, "connection reset")
+        except ConnectionResetError:
+            log.error("Fatal error on transport", exc_info=True)
+        log.error("Task exception was never retrieved")
+    finally:
+        log.removeHandler(catch)
+    assert [r.getMessage() for r in catch.records] == ["Task exception was never retrieved"]
+
+
+def test_the_filter_is_added_once():
+    logging_setup.configure_logging()
+    logging_setup.configure_logging()
+    n = sum(isinstance(f, logging_setup._ClientWentAway) for f in logging.getLogger("asyncio").filters)
+    assert n == 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -284,7 +284,8 @@ def test_queue_dub_starts_the_job_once_confirmed(monkeypatch, tmp_path):
                                source_language="ko", confirm=True)
     assert out == {"job_id": "j1", "status": "running"}
     assert calls["url"] == "%s/api/dub/start" % mcp_server.API
-    assert calls["data"]["language"] == "English"
+    # Perso's own name for the language on the Perso path (app/languages.py).
+    assert calls["data"]["language"] == "English (US)"
     assert calls["data"]["language_code"] == "en"
     assert calls["data"]["dub_mode"] == "perso"
     assert calls["data"]["source_language_code"] == "ko"
@@ -570,3 +571,21 @@ def test_download_model_says_when_it_is_already_there_or_unknown(monkeypatch):
     assert mcp_server.download_model("hunyuan")["state"] == "ready"
     with pytest.raises(ValueError, match="No such model"):
         mcp_server.download_model("llama")
+
+
+def test_queue_dub_knows_persos_languages_on_the_perso_path_only(monkeypatch, tmp_path):
+    from app import languages
+    monkeypatch.setattr(languages, "_fetch", lambda: None)
+    video = _tmp_video(tmp_path)
+    with pytest.raises(ValueError, match="target_language"):
+        mcp_server.queue_dub(str(video), "hi", confirm=True)          # the local voices cannot
+    calls = {}
+
+    def fake_post(url, data=None, files=None, timeout=None):
+        calls["data"] = data
+        return _Response(200, {"job_id": "j1", "status": "running"})
+
+    monkeypatch.setattr(mcp_server.httpx, "post", fake_post)
+    out = mcp_server.queue_dub(str(video), "hi", dub_mode="perso", confirm=True)
+    assert out["job_id"] == "j1"
+    assert calls["data"]["language"] == "Hindi" and calls["data"]["language_code"] == "hi"

--- a/tests/test_perso.py
+++ b/tests/test_perso.py
@@ -852,3 +852,19 @@ def test_download_target_scans_for_the_link_and_saves(monkeypatch, tmp_path):
     out = tmp_path / "bg.src"
     client.download_target(409873, "backgroundAudio", str(out))
     assert out.read_bytes() == b"BG-BYTES"
+
+
+def test_dub_video_sends_the_region_tag_when_the_language_has_one(monkeypatch, tmp_path):
+    # Perso tells English (UK) from English (US) by languageTag, not by code
+    # (app/languages.py); a plain code carries no tag at all.
+    calls = _install_fake_perso_dub_http(
+        monkeypatch,
+        progress_sequence=[{"progressReason": "Completed", "hasFailed": False}],
+    )
+    monkeypatch.setattr(perso_client_module.time, "sleep", lambda s: None)
+    src = tmp_path / "in.mp4"
+    src.write_bytes(b"v")
+    pc = PersoClient(api_key="dummy-key", space_seq=999, poll_interval=0)
+    pc.dub_video(str(src), str(tmp_path / "out.mp4"), "ko", "en", num_speakers=1, target_tag="en-GB")
+    url, body = next(c for c in calls["post"] if c[0].endswith("/translate"))
+    assert body["targetLanguages"] == [{"languageCode": "en", "ttsModel": "AUDIO_ENGINE_V3", "languageTag": "en-GB"}]

--- a/tests/test_routes_table.py
+++ b/tests/test_routes_table.py
@@ -46,6 +46,7 @@ ROUTES = [
     ('GET', '/api/dub/result/{jid}/subtitle_preview'),
     ('GET', '/api/dub/result/{jid}/subtitled'),
     ('GET', '/api/engines'),
+    ('GET', '/api/languages'),
     ('GET', '/api/models'),
     ('GET', '/api/perso/spaces'),
     ('GET', '/api/settings'),

--- a/tests/test_subtitle_ass.py
+++ b/tests/test_subtitle_ass.py
@@ -209,3 +209,39 @@ def test_the_weight_reaches_every_look():
         ass = build_ass(cue, preset, width=1920, height=1080, layout=lay)
         events = [l for l in ass.splitlines() if l.startswith("Dialogue:")]
         assert all("\\b800" in e for e in events), preset
+
+
+# libass sizes a font by its cell (ascent + descent), not its em: Fontsize 100
+# draws Apple SD Gothic Neo at 83 px and Malgun Gothic at 75 px, while the
+# page measured the layout at a true 100 px em. Measured 2026-09-08 with ten
+# capital H: Chromium 668 px vs libass 542 px on Mac, 530 px on Windows.
+def _style_size(ass):
+    return int([l for l in ass.splitlines() if l.startswith("Style: Base,")][0].split(",")[2])
+
+
+def test_the_style_font_size_is_scaled_by_the_fonts_cell_height():
+    # font_px for black-box at size 150 in 1080p is 52
+    for font, cell in (("Apple SD Gothic Neo", 1.2), ("Malgun Gothic", 1.33),
+                       ("Noto Sans CJK KR", 1.448), ("Arial", 1.0)):
+        ass = build_ass(SOUL_CUE, "black-box", width=1920, height=1080, size=150,
+                        font=font, layout=SOUL_LAYOUT)
+        assert _style_size(ass) == round(52 * cell), font
+        # The box and the words' place come from the page's em, unchanged.
+        assert "l 998 0 l 998 84 l 0 84" in ass, font
+
+
+def test_malgun_gothic_gets_its_bold_face_for_a_semibold_layout():
+    # Malgun Gothic ships regular and bold only; the browser maps 600 to bold,
+    # libass to regular, so White Box came out thin on Windows (2026-09-08).
+    lay = {"1": {**SOUL_LAYOUT["1"], "weight": 600}}
+    ass = build_ass(SOUL_CUE, "white-box", width=1920, height=1080, font="Malgun Gothic", layout=lay)
+    words = [l for l in ass.splitlines() if l.startswith("Dialogue: 1,")][0]
+    assert "\\b1" in words.split("}")[0] and "\\b600" not in words
+    lay = {"1": {**SOUL_LAYOUT["1"], "weight": 400}}
+    ass = build_ass(SOUL_CUE, "white-box", width=1920, height=1080, font="Malgun Gothic", layout=lay)
+    words = [l for l in ass.splitlines() if l.startswith("Dialogue: 1,")][0]
+    assert "\\b0" in words.split("}")[0]
+    # Fonts with the in-between weights keep the exact one, as before.
+    lay = {"1": {**SOUL_LAYOUT["1"], "weight": 600}}
+    ass = build_ass(SOUL_CUE, "white-box", width=1920, height=1080, font="Apple SD Gothic Neo", layout=lay)
+    assert "\\b600" in ass

--- a/ui/src/dubApi.mjs
+++ b/ui/src/dubApi.mjs
@@ -63,6 +63,25 @@ function qualityModeToNTakes(qualityMode) {
  * @param {{start: number, end: number}} [opts.trim] - dub only this part of the video, in seconds
  * @returns {FormData}
  */
+/**
+ * The languages each dubbing path offers, from GET /api/languages:
+ * {local: [{id, code, name, tag}], perso: [...]}. Perso's list is the one it
+ * publishes (77 entries, 2026-09-08); the local one is the model's ten. When
+ * the app cannot answer, both fall back to LANGUAGES so the dialog still works.
+ */
+export async function fetchLanguages({ baseUrl = "" } = {}) {
+  const fallback = LANGUAGES.map((l) => ({ id: l.code, code: l.code, name: l.name, tag: null }));
+  try {
+    const r = await fetch(`${baseUrl}/api/languages`);
+    if (!r.ok) return { local: fallback, perso: fallback };
+    const d = await r.json();
+    const ok = (xs) => Array.isArray(xs) && xs.length ? xs : fallback;
+    return { local: ok(d.local), perso: ok(d.perso) };
+  } catch {
+    return { local: fallback, perso: fallback };
+  }
+}
+
 export function buildDubFormData(opts) {
   if (!opts || (!opts.video && !opts.sourceUrl)) {
     throw new Error("A video file or a link is required.");
@@ -74,10 +93,14 @@ export function buildDubFormData(opts) {
     if (opts.sourceLang === opts.targetLang) {
       throw new Error("Source and target languages must be different.");
     }
-    const target = LANGUAGES.find((l) => l.code === opts.targetLang);
+    // opts.languages is the list the dialog is showing for the chosen path
+    // (Perso's own, or the model's ten); an entry's id is what the server
+    // takes as language_code -- a region tag such as en-GB, else the code.
+    const list = opts.languages || LANGUAGES;
+    const target = list.find((l) => (l.id || l.code) === opts.targetLang);
     if (!target) throw new Error(`Unsupported target language: ${opts.targetLang}`);
     language = target.name;
-    language_code = target.code;
+    language_code = target.id || target.code;
     sourceCode = opts.sourceLang;
   } else {
     ({ language, language_code } = directionToLanguage(opts.direction));

--- a/ui/src/modelsDialog.mjs
+++ b/ui/src/modelsDialog.mjs
@@ -47,7 +47,9 @@ export function initModelsUi({ $, onStartDubbing, onOpenSettings, onRowsChanged,
   if (shell && shell.onInstallProgress) {
     shell.onInstallProgress((p) => {
       if (!p || !p.pack || !packBusy || packBusy.id !== p.pack) return;
-      packBusy.line = p.state === "progress" && p.detail ? `${p.title}: ${p.detail}` : (p.title || "");
+      // A detail that only restates the title ("Downloading the translation
+      // runtime: Downloading the translation runtime", 2026-09-08) shows once.
+      packBusy.line = p.state === "progress" && p.detail && p.detail !== p.title ? `${p.title}: ${p.detail}` : (p.title || "");
       // The shell sends the pack's overall percent on every event.
       if (p.pct != null) packBusy.pct = p.pct;
       repaint();

--- a/ui/src/modelsDialog.mjs
+++ b/ui/src/modelsDialog.mjs
@@ -319,7 +319,9 @@ export function initModelsUi({ $, onStartDubbing, onOpenSettings, onRowsChanged,
     $("mnItems").hidden = true;   // the list said what; the bar now says how far
     $("mnAlt").hidden = true;
     if (packBusy) {
-      $("mnTitle").textContent = `Installing ${packBusy.name}`;
+      // The percent lives in the title, where the eye lands; the line below
+      // says what step the installer is on (2026-09-08: only the bar moved).
+      $("mnTitle").textContent = packBusy.pct != null ? `Installing ${packBusy.name} · ${packBusy.pct}%` : `Installing ${packBusy.name}`;
       $("mnLine").textContent = packBusy.line || "Starting…";
       return;
     }
@@ -378,7 +380,9 @@ export function initModelsUi({ $, onStartDubbing, onOpenSettings, onRowsChanged,
     })();
   });
   $("mnSettings").addEventListener("click", () => onOpenSettings());
-  $("mnHide").addEventListener("click", () => $("modelsNeededOverlay").classList.remove("open"));
+  // Hidden, the download shows as the top-bar chip instead -- the page draws
+  // that chip only while this dialog is closed, so it needs a repaint now.
+  $("mnHide").addEventListener("click", () => { $("modelsNeededOverlay").classList.remove("open"); repaint(); });
   $("mnCancel").addEventListener("click", () => {
     if (packBusy) cancelPack(packBusy.id);
     if (pendingDub && pendingDub.downloading) {

--- a/ui/src/modelsDialog.test.mjs
+++ b/ui/src/modelsDialog.test.mjs
@@ -407,6 +407,10 @@ test("while a pack installs the dialog shows its progress line, and Cancel stops
   shell.progress({ pack: "engine", stepId: "venv-engines", title: "Installing AI engines", state: "progress", detail: "torch 40%", pct: 40 });
   assert.equal(h.$("mnLine").textContent, "Installing AI engines: torch 40%");
   assert.equal(h.$("mnBar").style.width, "40%", "the bar follows the pack's percent, not the engine's row");
+  // A detail that only restates the title is not repeated after a colon
+  // ("Downloading the translation runtime: Downloading the translation runtime", 2026-09-08).
+  shell.progress({ pack: "engine", stepId: "ollama-runtime", title: "Downloading the translation runtime", state: "progress", detail: "Downloading the translation runtime", pct: 60 });
+  assert.equal(h.$("mnLine").textContent, "Downloading the translation runtime");
   h.$("mnCancel").click();
   assert.deepEqual(shell.asked, ["install engine", "cancel engine"]);
   finish({ ok: false, reason: "Cancelled." });

--- a/ui/src/modelsDialog.test.mjs
+++ b/ui/src/modelsDialog.test.mjs
@@ -262,8 +262,10 @@ test("Hide leaves the dub pending, and the topbar chip brings the dialog back", 
   t.after(h.state.restore);
   h.api.showModelsDialog(DETAIL_TWO);
 
+  const paintsBefore = h.state.painted.length;
   h.$("mnHide").click();
   assert.equal(h.$("modelsNeededOverlay").classList.contains("open"), false);
+  assert.equal(h.state.painted.length, paintsBefore + 1, "the page repaints, so its chip can show in the dialog's place");
 
   h.api.reopenDialogOrSettings();
   assert.equal(h.$("modelsNeededOverlay").classList.contains("open"), true);
@@ -407,6 +409,7 @@ test("while a pack installs the dialog shows its progress line, and Cancel stops
   shell.progress({ pack: "engine", stepId: "venv-engines", title: "Installing AI engines", state: "progress", detail: "torch 40%", pct: 40 });
   assert.equal(h.$("mnLine").textContent, "Installing AI engines: torch 40%");
   assert.equal(h.$("mnBar").style.width, "40%", "the bar follows the pack's percent, not the engine's row");
+  assert.equal(h.$("mnTitle").textContent, "Installing AI engine · 40%", "the title says how far, not only the bar");
   h.$("mnCancel").click();
   assert.deepEqual(shell.asked, ["install engine", "cancel engine"]);
   finish({ ok: false, reason: "Cancelled." });

--- a/ui/src/newProject.mjs
+++ b/ui/src/newProject.mjs
@@ -20,9 +20,24 @@ import { fmtClock, fmtClockTenths } from "./format.mjs";
 // is the single most-glanced-at line in the dialog, and a flag says it faster
 // than a word. The Original dropdown stays plain -- its default is not a
 // country at all ("Auto-detect"), so a half-flagged list would only look broken.
+// One flag per language the app can dub into, keyed by the language's id
+// (a region tag such as en-GB where Perso tells variants apart, else the
+// code). A language spoken in many countries gets the country it is most
+// associated with (Arabic: Saudi Arabia, Swahili: Kenya, the Indian
+// languages: India); Welsh gets the Welsh flag. Windows draws these as
+// two-letter codes -- its emoji font has no flags -- which is how the
+// original ten already looked there.
 const LANG_FLAGS = {
-  en: "🇺🇸", ko: "🇰🇷", zh: "🇨🇳", fr: "🇫🇷", de: "🇩🇪",
-  it: "🇮🇹", ja: "🇯🇵", pt: "🇵🇹", ru: "🇷🇺", es: "🇪🇸",
+  "af": "🇿🇦", "ar": "🇸🇦", "as": "🇮🇳", "az": "🇦🇿", "be": "🇧🇾", "bg": "🇧🇬", "bn": "🇧🇩", "bs": "🇧🇦",
+  "ca": "🇪🇸", "ceb": "🇵🇭", "cs": "🇨🇿", "cy": "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "da": "🇩🇰", "de": "🇩🇪", "el": "🇬🇷", "en": "🇺🇸",
+  "en-GB": "🇬🇧", "es": "🇲🇽", "es-ES": "🇪🇸", "et": "🇪🇪", "fa": "🇮🇷", "fi": "🇫🇮", "fil": "🇵🇭", "fr": "🇫🇷",
+  "ga": "🇮🇪", "gl": "🇪🇸", "gu": "🇮🇳", "ha": "🇳🇬", "he": "🇮🇱", "hi": "🇮🇳", "hr": "🇭🇷", "hu": "🇭🇺",
+  "hy": "🇦🇲", "id": "🇮🇩", "is": "🇮🇸", "it": "🇮🇹", "ja": "🇯🇵", "jv": "🇮🇩", "ka": "🇬🇪", "kk": "🇰🇿",
+  "kn": "🇮🇳", "ko": "🇰🇷", "ky": "🇰🇬", "lb": "🇱🇺", "ln": "🇨🇩", "lt": "🇱🇹", "lv": "🇱🇻", "mk": "🇲🇰",
+  "ml": "🇮🇳", "mr": "🇮🇳", "ms": "🇲🇾", "ne": "🇳🇵", "nl": "🇳🇱", "no": "🇳🇴", "ny": "🇲🇼", "pa": "🇮🇳",
+  "pl": "🇵🇱", "ps": "🇦🇫", "pt": "🇧🇷", "pt-PT": "🇵🇹", "ro": "🇷🇴", "ru": "🇷🇺", "sd": "🇵🇰", "sk": "🇸🇰",
+  "sl": "🇸🇮", "so": "🇸🇴", "sr": "🇷🇸", "sv": "🇸🇪", "sw": "🇰🇪", "ta": "🇮🇳", "te": "🇮🇳", "th": "🇹🇭",
+  "tr": "🇹🇷", "uk": "🇺🇦", "ur": "🇵🇰", "vi": "🇻🇳", "zh": "🇨🇳",
 };
 
 // The shortest part worth dubbing; also what keeps the two handles from
@@ -101,9 +116,7 @@ export function initNewProjectUi({ $, state, onStart, applyEngineAvailability,
     for (const l of list) {
       const o = document.createElement("option");
       o.value = l.id;
-      // Flags exist for the ten; a regional variant (en-GB) goes without one
-      // rather than borrowing its parent's.
-      const flag = !l.tag && LANG_FLAGS[l.code];
+      const flag = LANG_FLAGS[l.id] || (!l.tag && LANG_FLAGS[l.code]);
       o.textContent = flag ? `${flag} ${l.name}` : l.name;
       sel.appendChild(o);
     }

--- a/ui/src/newProject.mjs
+++ b/ui/src/newProject.mjs
@@ -24,16 +24,17 @@ import { fmtClock, fmtClockTenths } from "./format.mjs";
 // (a region tag such as en-GB where Perso tells variants apart, else the
 // code). A language spoken in many countries gets the country it is most
 // associated with (Arabic: Saudi Arabia, Swahili: Kenya, the Indian
-// languages: India); Welsh gets the Welsh flag. Windows draws these as
-// two-letter codes -- its emoji font has no flags -- which is how the
-// original ten already looked there.
+// languages: India); Welsh gets the Union Jack -- the Welsh flag is a tag
+// sequence that Windows draws as a bare black flag, unlike the two-letter
+// codes it draws for every other flag here (its emoji font has none), which
+// is how the original ten already looked there.
 // The local list says plainly "Portuguese" and "Spanish": those keep the
 // flags they always had. Perso's default regions for the same codes are
 // Brazil and Mexico, which is what the Perso list shows.
 const LOCAL_FLAGS = { pt: "🇵🇹", es: "🇪🇸" };
 const LANG_FLAGS = {
   "af": "🇿🇦", "ar": "🇸🇦", "as": "🇮🇳", "az": "🇦🇿", "be": "🇧🇾", "bg": "🇧🇬", "bn": "🇧🇩", "bs": "🇧🇦",
-  "ca": "🇪🇸", "ceb": "🇵🇭", "cs": "🇨🇿", "cy": "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "da": "🇩🇰", "de": "🇩🇪", "el": "🇬🇷", "en": "🇺🇸",
+  "ca": "🇪🇸", "ceb": "🇵🇭", "cs": "🇨🇿", "cy": "🇬🇧", "da": "🇩🇰", "de": "🇩🇪", "el": "🇬🇷", "en": "🇺🇸",
   "en-GB": "🇬🇧", "es": "🇲🇽", "es-ES": "🇪🇸", "et": "🇪🇪", "fa": "🇮🇷", "fi": "🇫🇮", "fil": "🇵🇭", "fr": "🇫🇷",
   "ga": "🇮🇪", "gl": "🇪🇸", "gu": "🇮🇳", "ha": "🇳🇬", "he": "🇮🇱", "hi": "🇮🇳", "hr": "🇭🇷", "hu": "🇭🇺",
   "hy": "🇦🇲", "id": "🇮🇩", "is": "🇮🇸", "it": "🇮🇹", "ja": "🇯🇵", "jv": "🇮🇩", "ka": "🇬🇪", "kk": "🇰🇿",

--- a/ui/src/newProject.mjs
+++ b/ui/src/newProject.mjs
@@ -27,6 +27,10 @@ import { fmtClock, fmtClockTenths } from "./format.mjs";
 // languages: India); Welsh gets the Welsh flag. Windows draws these as
 // two-letter codes -- its emoji font has no flags -- which is how the
 // original ten already looked there.
+// The local list says plainly "Portuguese" and "Spanish": those keep the
+// flags they always had. Perso's default regions for the same codes are
+// Brazil and Mexico, which is what the Perso list shows.
+const LOCAL_FLAGS = { pt: "🇵🇹", es: "🇪🇸" };
 const LANG_FLAGS = {
   "af": "🇿🇦", "ar": "🇸🇦", "as": "🇮🇳", "az": "🇦🇿", "be": "🇧🇾", "bg": "🇧🇬", "bn": "🇧🇩", "bs": "🇧🇦",
   "ca": "🇪🇸", "ceb": "🇵🇭", "cs": "🇨🇿", "cy": "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "da": "🇩🇰", "de": "🇩🇪", "el": "🇬🇷", "en": "🇺🇸",
@@ -88,7 +92,8 @@ export function initNewProjectUi({ $, state, onStart, applyEngineAvailability,
       for (const l of LANGUAGES) {
         const o = document.createElement("option");
         o.value = l.code;
-        o.textContent = withFlag && LANG_FLAGS[l.code] ? `${LANG_FLAGS[l.code]} ${l.name}` : l.name;
+        const flag = LOCAL_FLAGS[l.code] || LANG_FLAGS[l.code];
+        o.textContent = withFlag && flag ? `${flag} ${l.name}` : l.name;
         if (l.code === defCode) o.selected = true;
         sel.appendChild(o);
       }
@@ -112,11 +117,12 @@ export function initNewProjectUi({ $, state, onStart, applyEngineAvailability,
     if (!sel) return;
     const keep = sel.value || "en";
     const list = currentLanguages();
+    const local = list === languageLists.local;
     sel.innerHTML = "";
     for (const l of list) {
       const o = document.createElement("option");
       o.value = l.id;
-      const flag = LANG_FLAGS[l.id] || (!l.tag && LANG_FLAGS[l.code]);
+      const flag = (local && LOCAL_FLAGS[l.code]) || LANG_FLAGS[l.id] || (!l.tag && LANG_FLAGS[l.code]);
       o.textContent = flag ? `${flag} ${l.name}` : l.name;
       sel.appendChild(o);
     }

--- a/ui/src/newProject.mjs
+++ b/ui/src/newProject.mjs
@@ -13,7 +13,7 @@
 // playRange/cancelRange, which the finished screen plays its lines with.
 //
 // Everything this file touches is #projectOverlay and its children.
-import { LANGUAGES } from "./dubApi.mjs";
+import { LANGUAGES, fetchLanguages } from "./dubApi.mjs";
 import { fmtClock, fmtClockTenths } from "./format.mjs";
 
 // The flags are the app's one deliberate use of emoji: where the dub is headed
@@ -81,6 +81,40 @@ export function initNewProjectUi({ $, state, onStart, applyEngineAvailability,
   }
   fillLanguageSelects();
 
+  // The target list follows the dubbing path: Perso's own languages (77 on
+  // 2026-09-08, with regional variants such as English (UK)) when the cloud
+  // dubs, the model's ten when this computer does. Until GET /api/languages
+  // answers, both paths show the ten. The source dropdown stays as it is:
+  // "Auto-detect" covers the cloud, and the ten are what Whisper is asked for.
+  const asEntries = (xs) => xs.map((l) => ({ id: l.id || l.code, code: l.code, name: l.name, tag: l.tag || null }));
+  let languageLists = { local: asEntries(LANGUAGES), perso: asEntries(LANGUAGES) };
+  function currentLanguages() {
+    const mode = $("dubModeSelect") ? $("dubModeSelect").value : "local";
+    return languageLists[mode === "perso" ? "perso" : "local"];
+  }
+  function refillTargetLanguages() {
+    const sel = $("targetLangSelect");
+    if (!sel) return;
+    const keep = sel.value || "en";
+    const list = currentLanguages();
+    sel.innerHTML = "";
+    for (const l of list) {
+      const o = document.createElement("option");
+      o.value = l.id;
+      // Flags exist for the ten; a regional variant (en-GB) goes without one
+      // rather than borrowing its parent's.
+      const flag = !l.tag && LANG_FLAGS[l.code];
+      o.textContent = flag ? `${flag} ${l.name}` : l.name;
+      sel.appendChild(o);
+    }
+    sel.value = list.some((l) => l.id === keep) ? keep : "en";
+  }
+  fetchLanguages().then((lists) => {
+    languageLists = { local: asEntries(lists.local), perso: asEntries(lists.perso) };
+    refillTargetLanguages();
+  });
+  if ($("dubModeSelect")) $("dubModeSelect").addEventListener("change", refillTargetLanguages);
+
   // The dropdowns start on the app's saved defaults (GET /api/setup: kit.env,
   // written by Settings or the Dub Agent's set_default), so what the agent
   // changed is what the dialog shows, and a choice survives a relaunch.
@@ -96,6 +130,7 @@ export function initNewProjectUi({ $, state, onStart, applyEngineAvailability,
       if (sel && value && sel.querySelector(`option[value="${value}"]`)) sel.value = value;
     };
     pick("dubModeSelect", d.dub_mode);
+    refillTargetLanguages();
     pick("sepSelect", d.separation);
     pick("sttSelect", d.stt);
     pick("translateSelect", d.translator);
@@ -400,6 +435,7 @@ export function initNewProjectUi({ $, state, onStart, applyEngineAvailability,
       sourceUrl: np.probe ? np.probe.url : null,
       sourceLang: $("sourceLangSelect").value,
       targetLang: $("targetLangSelect").value,
+      languages: currentLanguages(),
       sttEngine: $("sttSelect").value,
       sepEngine: $("sepSelect").value,
       dubMode: $("dubModeSelect").value,

--- a/ui/src/newProject.test.mjs
+++ b/ui/src/newProject.test.mjs
@@ -488,4 +488,10 @@ test("every Perso language gets a flag, regional variants their own country", as
   assert.ok(byId["en-GB"].startsWith("🇬🇧") && byId["en"].startsWith("🇺🇸"), "UK and US English differ");
   assert.ok(byId["pt"].startsWith("🇧🇷") && byId["pt-PT"].startsWith("🇵🇹"));
   assert.ok(byId["es"].startsWith("🇲🇽") && byId["es-ES"].startsWith("🇪🇸"));
+  // Back on the local list, plain Portuguese and Spanish keep their own flags.
+  h.$("dubModeSelect").value = "local";
+  await h.$("dubModeSelect").fire("change");
+  const localById = Object.fromEntries(h.$("targetLangSelect").options.map((o) => [o.value, o.textContent]));
+  assert.equal(localById["pt"], "🇵🇹 Portuguese");
+  assert.equal(localById["es"], "🇪🇸 Spanish");
 });

--- a/ui/src/newProject.test.mjs
+++ b/ui/src/newProject.test.mjs
@@ -9,6 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { initNewProjectUi } from "./newProject.mjs";
+import { LANGUAGES } from "./dubApi.mjs";
 
 function makeEl(id) {
   const classes = new Set();
@@ -324,9 +325,10 @@ test("an engine that will not answer leaves the form on its shipped defaults", a
 
 // -- what a dub is started with -------------------------------------------
 
-test("readOptions hands back the whole form, field for field", (t) => {
+test("readOptions hands back the whole form, field for field", async (t) => {
   const h = harness();
   t.after(h.log.restore);
+  await new Promise((r) => setTimeout(r, 0));   // the language lists have been asked for
   const file = { name: "a.mp4" };
   h.state.newProject = { file, files: null, probe: null, trim: { start: 1, end: 9 } };
   h.$("sourceLangSelect").value = "ko";
@@ -349,6 +351,9 @@ test("readOptions hands back the whole form, field for field", (t) => {
     qualityMode: "high",
     numSpeakers: 2,
     translateEngine: "gemini",
+    // The list the target was picked from (the model's ten until the app
+    // answers /api/languages; this harness answers nothing useful).
+    languages: LANGUAGES.map((l) => ({ id: l.code, code: l.code, name: l.name, tag: null })),
     project: undefined,
     trim: { start: 1, end: 9 },
   });

--- a/ui/src/newProject.test.mjs
+++ b/ui/src/newProject.test.mjs
@@ -468,3 +468,24 @@ test("Start hands the job back to the page", (t) => {
 
   assert.equal(h.log.started, 1);
 });
+
+
+test("every Perso language gets a flag, regional variants their own country", async (t) => {
+  // The bundled list is the one the app ships (app/perso_languages.json).
+  const { readFileSync } = await import("node:fs");
+  const perso = JSON.parse(readFileSync(new URL("../../app/perso_languages.json", import.meta.url), "utf8")).languages
+    .map((l) => ({ id: l.tag || l.code, code: l.code, name: l.name, tag: l.tag }));
+  const h = harness({ responses: { "/api/languages": { ok: true, json: async () => ({ local: [], perso }) } } });
+  t.after(h.log.restore);
+  await new Promise((r) => setTimeout(r, 0));
+  h.$("dubModeSelect").value = "perso";
+  await h.$("dubModeSelect").fire("change");
+  const opts = h.$("targetLangSelect").options;
+  assert.equal(opts.length, perso.length);
+  const bare = opts.filter((o) => !/^\p{Extended_Pictographic}|^\p{Regional_Indicator}/u.test(o.textContent));
+  assert.deepEqual(bare.map((o) => o.value), [], "every option starts with a flag");
+  const byId = Object.fromEntries(opts.map((o) => [o.value, o.textContent]));
+  assert.ok(byId["en-GB"].startsWith("🇬🇧") && byId["en"].startsWith("🇺🇸"), "UK and US English differ");
+  assert.ok(byId["pt"].startsWith("🇧🇷") && byId["pt-PT"].startsWith("🇵🇹"));
+  assert.ok(byId["es"].startsWith("🇲🇽") && byId["es-ES"].startsWith("🇪🇸"));
+});


### PR DESCRIPTION
0.5.4: Perso dubbing offers Perso's own languages, the download dialog says how far it is, and the fixes found while testing the 0.5.3 release.

- Perso dubbing lists the languages Perso publishes (77 on 2026-09-08, asked daily, kept locally, a bundled copy before that); the New project target list follows the dubbing path; regional variants (en-GB, es-ES, pt-PT) reach Perso as their languageTag; every entry carries a flag; dub start and the Dub Agent check the chosen path's list.
- The download dialog's title carries the pack's percent; the top-bar chip shows only after Hide; the percent holds through lines that carry none.
- Burned subtitles are as large as the screen's (libass sizes by the font's cell), and an export is burned again when an update draws it differently.
- Windows: the update installs silently and relaunches; the lock check answers in UTF-8; the release carries its blockmap for differential updates.
- A download that broke mid-way says so in one sentence; a progress detail that restates its title shows once; the kit abandoned on the 0.3.0 path move is removed once its models are carried over (issue #6); asyncio's client-disconnect noise stays out of the log.

Verified on Mac (fresh install, update over 0.5.2, local and Perso dubs incl. Hindi, subtitle export) and Windows (from source: pack install, dub, export, dialog percent, languages). pytest 1136, ui 245, desktop 221, ruff clean, gitleaks clean.
